### PR TITLE
Fix a false positive and incorrect autocorrect for `Capybara/SpecificActions`, `Capybara/SpecificFinders` and `Capybara/SpecificMatcher`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -91,6 +91,10 @@ RSpec/DescribeClass:
   Exclude:
     - spec/project/**/*.rb
 
+RSpec/FilePath:
+  Exclude:
+    - spec/rubocop/cop/capybara/mixin/**/*.rb
+
 RSpec/MultipleExpectations:
   Max: 2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix an incorrect autocorrect for `Capybara/CurrentPathExpectation`. ([@ydah])
 - Fix a false negative for `Capybara/CurrentPathExpectation` when using `match`. ([@ydah])
+- Fix a false positive and incorrect autocorrect for `Capybara/SpecificActions`, `Capybara/SpecificFinders` and `Capybara/SpecificMatcher`. ([@ydah])
 
 ## 2.17.0 (2022-12-29)
 

--- a/lib/rubocop/cop/capybara/mixin/capybara_help.rb
+++ b/lib/rubocop/cop/capybara/mixin/capybara_help.rb
@@ -2,76 +2,128 @@
 
 module RuboCop
   module Cop
-    # Help methods for capybara.
-    module CapybaraHelp
-      module_function
+    module Capybara
+      # Help methods for capybara.
+      module CapybaraHelp
+        COMMON_OPTIONS = %w[
+          id class style
+        ].freeze
+        SPECIFIC_OPTIONS = {
+          'button' => (
+            COMMON_OPTIONS + %w[disabled name value title type]
+          ).freeze,
+          'link' => (
+            COMMON_OPTIONS + %w[href alt title download]
+          ).freeze,
+          'table' => (
+            COMMON_OPTIONS + %w[cols rows]
+          ).freeze,
+          'select' => (
+            COMMON_OPTIONS + %w[
+              disabled name placeholder
+              selected multiple
+            ]
+          ).freeze,
+          'field' => (
+            COMMON_OPTIONS + %w[
+              checked disabled name placeholder
+              readonly type multiple
+            ]
+          ).freeze
+        }.freeze
+        SPECIFIC_PSEUDO_CLASSES = %w[
+          not() disabled enabled checked unchecked
+        ].freeze
 
-      # @param node [RuboCop::AST::SendNode]
-      # @param locator [String]
-      # @param element [String]
-      # @return [Boolean]
-      def specific_option?(node, locator, element)
-        attrs = CssSelector.attributes(locator).keys
-        return false unless replaceable_element?(node, element, attrs)
+        module_function
 
-        attrs.all? do |attr|
-          CssSelector.specific_options?(element, attr)
-        end
-      end
+        # @param node [RuboCop::AST::SendNode]
+        # @param locator [String]
+        # @param element [String]
+        # @return [Boolean]
+        def replaceable_option?(node, locator, element)
+          attrs = CssSelector.attributes(locator).keys
+          return false unless replaceable_element?(node, element, attrs)
 
-      # @param locator [String]
-      # @return [Boolean]
-      def specific_pseudo_classes?(locator)
-        CssSelector.pseudo_classes(locator).all? do |pseudo_class|
-          replaceable_pseudo_class?(pseudo_class, locator)
-        end
-      end
-
-      # @param pseudo_class [String]
-      # @param locator [String]
-      # @return [Boolean]
-      def replaceable_pseudo_class?(pseudo_class, locator)
-        return false unless CssSelector.specific_pesudo_classes?(pseudo_class)
-
-        case pseudo_class
-        when 'not()' then replaceable_pseudo_class_not?(locator)
-        else true
-        end
-      end
-
-      # @param locator [String]
-      # @return [Boolean]
-      def replaceable_pseudo_class_not?(locator)
-        locator.scan(/not\(.*?\)/).all? do |negation|
-          CssSelector.attributes(negation).values.all? do |v|
-            v.is_a?(TrueClass) || v.is_a?(FalseClass)
+          attrs.all? do |attr|
+            SPECIFIC_OPTIONS.fetch(element, []).include?(attr)
           end
         end
-      end
 
-      # @param node [RuboCop::AST::SendNode]
-      # @param element [String]
-      # @param attrs [Array<String>]
-      # @return [Boolean]
-      def replaceable_element?(node, element, attrs)
-        case element
-        when 'link' then replaceable_to_link?(node, attrs)
-        else true
+        # @param selector [String]
+        # @return [Boolean]
+        # @example
+        #   common_attributes?('a[focused]') # => true
+        #   common_attributes?('button[focused][visible]') # => true
+        #   common_attributes?('table[id=some-id]') # => true
+        #   common_attributes?('h1[invalid]') # => false
+        def common_attributes?(selector)
+          CssSelector.attributes(selector).keys.difference(COMMON_OPTIONS).none?
         end
-      end
 
-      # @param node [RuboCop::AST::SendNode]
-      # @param attrs [Array<String>]
-      # @return [Boolean]
-      def replaceable_to_link?(node, attrs)
-        include_option?(node, :href) || attrs.include?('href')
-      end
+        # @param attrs [Array<String>]
+        # @return [Boolean]
+        # @example
+        #   replaceable_attributes?('table[id=some-id]') # => true
+        #   replaceable_attributes?('a[focused]') # => false
+        def replaceable_attributes?(attrs)
+          attrs.values.none?(&:nil?)
+        end
 
-      # @param node [RuboCop::AST::SendNode]
-      # @param option [Symbol]
-      # @return [Boolean]
-      def include_option?(node, option)
-        node.each_descendant(:sym).find { |opt| opt.value == option }
+        # @param locator [String]
+        # @return [Boolean]
+        def replaceable_pseudo_classes?(locator)
+          CssSelector.pseudo_classes(locator).all? do |pseudo_class|
+            replaceable_pseudo_class?(pseudo_class, locator)
+          end
+        end
+
+        # @param pseudo_class [String]
+        # @param locator [String]
+        # @return [Boolean]
+        def replaceable_pseudo_class?(pseudo_class, locator)
+          return false unless SPECIFIC_PSEUDO_CLASSES.include?(pseudo_class)
+
+          case pseudo_class
+          when 'not()' then replaceable_pseudo_class_not?(locator)
+          else true
+          end
+        end
+
+        # @param locator [String]
+        # @return [Boolean]
+        def replaceable_pseudo_class_not?(locator)
+          locator.scan(/not\(.*?\)/).all? do |negation|
+            CssSelector.attributes(negation).values.all? do |v|
+              v.is_a?(TrueClass) || v.is_a?(FalseClass)
+            end
+          end
+        end
+
+        # @param node [RuboCop::AST::SendNode]
+        # @param element [String]
+        # @param attrs [Array<String>]
+        # @return [Boolean]
+        def replaceable_element?(node, element, attrs)
+          case element
+          when 'link' then replaceable_to_link?(node, attrs)
+          else true
+          end
+        end
+
+        # @param node [RuboCop::AST::SendNode]
+        # @param attrs [Array<String>]
+        # @return [Boolean]
+        def replaceable_to_link?(node, attrs)
+          include_option?(node, :href) || attrs.include?('href')
+        end
+
+        # @param node [RuboCop::AST::SendNode]
+        # @param option [Symbol]
+        # @return [Boolean]
+        def include_option?(node, option)
+          node.each_descendant(:sym).find { |opt| opt.value == option }
+        end
       end
     end
   end

--- a/lib/rubocop/cop/capybara/mixin/css_selector.rb
+++ b/lib/rubocop/cop/capybara/mixin/css_selector.rb
@@ -2,141 +2,107 @@
 
 module RuboCop
   module Cop
-    # Helps parsing css selector.
-    module CssSelector
-      COMMON_OPTIONS = %w[
-        above below left_of right_of near count minimum maximum between text
-        id class style visible obscured exact exact_text normalize_ws match
-        wait filter_set focused
-      ].freeze
-      SPECIFIC_OPTIONS = {
-        'button' => (
-          COMMON_OPTIONS + %w[disabled name value title type]
-        ).freeze,
-        'link' => (
-          COMMON_OPTIONS + %w[href alt title download]
-        ).freeze,
-        'table' => (
-          COMMON_OPTIONS + %w[
-            caption with_cols cols with_rows rows
-          ]
-        ).freeze,
-        'select' => (
-          COMMON_OPTIONS + %w[
-            disabled name placeholder options enabled_options
-            disabled_options selected with_selected multiple with_options
-          ]
-        ).freeze,
-        'field' => (
-          COMMON_OPTIONS + %w[
-            checked unchecked disabled valid name placeholder
-            validation_message readonly with type multiple
-          ]
-        ).freeze
-      }.freeze
-      SPECIFIC_PSEUDO_CLASSES = %w[
-        not() disabled enabled checked unchecked
-      ].freeze
+    module Capybara
+      # Helps parsing css selector.
+      module CssSelector
+        module_function
 
-      module_function
+        # @param selector [String]
+        # @return [String]
+        # @example
+        #   id('#some-id') # => some-id
+        #   id('.some-cls') # => nil
+        #   id('#some-id.cls') # => some-id
+        def id(selector)
+          return unless id?(selector)
 
-      # @param element [String]
-      # @param attribute [String]
-      # @return [Boolean]
-      # @example
-      #   specific_pesudo_classes?('button', 'name') # => true
-      #   specific_pesudo_classes?('link', 'invalid') # => false
-      def specific_options?(element, attribute)
-        SPECIFIC_OPTIONS.fetch(element, []).include?(attribute)
-      end
-
-      # @param pseudo_class [String]
-      # @return [Boolean]
-      # @example
-      #   specific_pesudo_classes?('disabled') # => true
-      #   specific_pesudo_classes?('first-of-type') # => false
-      def specific_pesudo_classes?(pseudo_class)
-        SPECIFIC_PSEUDO_CLASSES.include?(pseudo_class)
-      end
-
-      # @param selector [String]
-      # @return [Boolean]
-      # @example
-      #   id?('#some-id') # => true
-      #   id?('.some-class') # => false
-      def id?(selector)
-        selector.start_with?('#')
-      end
-
-      # @param selector [String]
-      # @return [Boolean]
-      # @example
-      #   attribute?('[attribute]') # => true
-      #   attribute?('attribute') # => false
-      def attribute?(selector)
-        selector.start_with?('[')
-      end
-
-      # @param selector [String]
-      # @return [Array<String>]
-      # @example
-      #   attributes('a[foo-bar_baz]') # => {"foo-bar_baz=>true}
-      #   attributes('button[foo][bar]') # => {"foo"=>true, "bar"=>true}
-      #   attributes('table[foo=bar]') # => {"foo"=>"'bar'"}
-      def attributes(selector)
-        selector.scan(/\[(.*?)\]/).flatten.to_h do |attr|
-          key, value = attr.split('=')
-          [key, normalize_value(value)]
+          selector.delete('#').gsub(selector.scan(/[^\\]([>,+~.].*)/).join, '')
         end
-      end
 
-      # @param selector [String]
-      # @return [Boolean]
-      # @example
-      #   common_attributes?('a[focused]') # => true
-      #   common_attributes?('button[focused][visible]') # => true
-      #   common_attributes?('table[id=some-id]') # => true
-      #   common_attributes?('h1[invalid]') # => false
-      def common_attributes?(selector)
-        attributes(selector).keys.difference(COMMON_OPTIONS).none?
-      end
+        # @param selector [String]
+        # @return [Boolean]
+        # @example
+        #   id?('#some-id') # => true
+        #   id?('.some-cls') # => false
+        def id?(selector)
+          selector.start_with?('#')
+        end
 
-      # @param selector [String]
-      # @return [Array<String>]
-      # @example
-      #   pseudo_classes('button:not([disabled])') # => ['not()']
-      #   pseudo_classes('a:enabled:not([valid])') # => ['enabled', 'not()']
-      def pseudo_classes(selector)
-        # Attributes must be excluded or else the colon in the `href`s URL
-        # will also be picked up as pseudo classes.
-        # "a:not([href='http://example.com']):enabled" => "a:not():enabled"
-        ignored_attribute = selector.gsub(/\[.*?\]/, '')
-        # "a:not():enabled" => ["not()", "enabled"]
-        ignored_attribute.scan(/:([^:]*)/).flatten
-      end
+        # @param selector [String]
+        # @return [Array<String>]
+        # @example
+        #   classes('#some-id') # => []
+        #   classes('.some-cls') # => ['some-cls']
+        #   classes('#some-id.some-cls') # => ['some-cls']
+        #   classes('#some-id.cls1.cls2') # => ['cls1', 'cls2']
+        def classes(selector)
+          selector.scan(/\.([\w-]*)/).flatten
+        end
 
-      # @param selector [String]
-      # @return [Boolean]
-      # @example
-      #   multiple_selectors?('a.cls b#id') # => true
-      #   multiple_selectors?('a.cls') # => false
-      def multiple_selectors?(selector)
-        selector.match?(/[ >,+~]/)
-      end
+        # @param selector [String]
+        # @return [Boolean]
+        # @example
+        #   attribute?('[attribute]') # => true
+        #   attribute?('attribute') # => false
+        def attribute?(selector)
+          selector.start_with?('[')
+        end
 
-      # @param value [String]
-      # @return [Boolean, String]
-      # @example
-      #   normalize_value('true') # => true
-      #   normalize_value('false') # => false
-      #   normalize_value(nil) # => false
-      #   normalize_value("foo") # => "'foo'"
-      def normalize_value(value)
-        case value
-        when 'true' then true
-        when 'false' then false
-        when nil then true
-        else "'#{value}'"
+        # @param selector [String]
+        # @return [Array<String>]
+        # @example
+        #   attributes('a[foo-bar_baz]') # => {"foo-bar_baz=>nil}
+        #   attributes('button[foo][bar=baz]') # => {"foo"=>nil, "bar"=>"'baz'"}
+        #   attributes('table[foo=bar]') # => {"foo"=>"'bar'"}
+        def attributes(selector)
+          # Extract the inner strings of attributes.
+          # For example, extract the following:
+          # 'button[foo][bar=baz]' => 'foo][bar=baz'
+          inside_attributes = selector.scan(/\[(.*)\]/).flatten.join
+          inside_attributes.split('][').to_h do |attr|
+            key, value = attr.split('=')
+            [key, normalize_value(value)]
+          end
+        end
+
+        # @param selector [String]
+        # @return [Array<String>]
+        # @example
+        #   pseudo_classes('button:not([disabled])') # => ['not()']
+        #   pseudo_classes('a:enabled:not([valid])') # => ['enabled', 'not()']
+        def pseudo_classes(selector)
+          # Attributes must be excluded or else the colon in the `href`s URL
+          # will also be picked up as pseudo classes.
+          # "a:not([href='http://example.com']):enabled" => "a:not():enabled"
+          ignored_attribute = selector.gsub(/\[.*?\]/, '')
+          # "a:not():enabled" => ["not()", "enabled"]
+          ignored_attribute.scan(/:([^:]*)/).flatten
+        end
+
+        # @param selector [String]
+        # @return [Boolean]
+        # @example
+        #   multiple_selectors?('a.cls b#id') # => true
+        #   multiple_selectors?('a.cls') # => false
+        def multiple_selectors?(selector)
+          normalize = selector.gsub(/(\\[>,+~]|\(.*\))/, '')
+          normalize.match?(/[ >,+~]/)
+        end
+
+        # @param value [String]
+        # @return [Boolean, String]
+        # @example
+        #   normalize_value('true') # => true
+        #   normalize_value('false') # => false
+        #   normalize_value(nil) # => nil
+        #   normalize_value("foo") # => "'foo'"
+        def normalize_value(value)
+          case value
+          when 'true' then true
+          when 'false' then false
+          when nil then nil
+          else "'#{value.gsub(/"|'/, '')}'"
+          end
         end
       end
     end

--- a/lib/rubocop/cop/capybara/specific_actions.rb
+++ b/lib/rubocop/cop/capybara/specific_actions.rb
@@ -41,9 +41,7 @@ module RuboCop
             # which the last selector points.
             next unless (selector = last_selector(arg))
             next unless (action = specific_action(selector))
-            next unless CapybaraHelp.specific_option?(node.receiver, arg,
-                                                      action)
-            next unless CapybaraHelp.specific_pseudo_classes?(arg)
+            next unless replaceable?(node, arg, action)
 
             range = offense_range(node, node.receiver)
             add_offense(range, message: message(action, selector))
@@ -54,6 +52,18 @@ module RuboCop
 
         def specific_action(selector)
           SPECIFIC_ACTION[last_selector(selector)]
+        end
+
+        def replaceable?(node, arg, action)
+          replaceable_attributes?(arg) &&
+            CapybaraHelp.replaceable_option?(node.receiver, arg, action) &&
+            CapybaraHelp.replaceable_pseudo_classes?(arg)
+        end
+
+        def replaceable_attributes?(selector)
+          CapybaraHelp.replaceable_attributes?(
+            CssSelector.attributes(selector)
+          )
         end
 
         def supported_selector?(selector)

--- a/lib/rubocop/cop/capybara/specific_finders.rb
+++ b/lib/rubocop/cop/capybara/specific_finders.rb
@@ -27,8 +27,14 @@ module RuboCop
           (send _ :find (str $_) ...)
         PATTERN
 
+        # @!method class_options(node)
+        def_node_search :class_options, <<~PATTERN
+          (pair (sym :class) $_ ...)
+        PATTERN
+
         def on_send(node)
           find_argument(node) do |arg|
+            next if CssSelector.pseudo_classes(arg).any?
             next if CssSelector.multiple_selectors?(arg)
 
             on_attr(node, arg) if attribute?(arg)
@@ -39,26 +45,55 @@ module RuboCop
         private
 
         def on_attr(node, arg)
-          return unless (id = CssSelector.attributes(arg)['id'])
+          attrs = CssSelector.attributes(arg)
+          return unless (id = attrs['id'])
+          return if attrs['class']
 
           register_offense(node, replaced_arguments(arg, id))
         end
 
         def on_id(node, arg)
-          register_offense(node, "'#{arg.to_s.delete('#')}'")
+          return if CssSelector.attributes(arg).any?
+
+          id = CssSelector.id(arg)
+          register_offense(node, "'#{id}'",
+                           CssSelector.classes(arg.sub("##{id}", '')))
         end
 
         def attribute?(arg)
           CssSelector.attribute?(arg) &&
-            CssSelector.common_attributes?(arg)
+            CapybaraHelp.common_attributes?(arg)
         end
 
-        def register_offense(node, arg_replacement)
+        def register_offense(node, id, classes = [])
           add_offense(offense_range(node)) do |corrector|
             corrector.replace(node.loc.selector, 'find_by_id')
             corrector.replace(node.first_argument.loc.expression,
-                              arg_replacement)
+                              id.delete('\\'))
+            unless classes.compact.empty?
+              autocorrect_classes(corrector, node, classes)
+            end
           end
+        end
+
+        def autocorrect_classes(corrector, node, classes)
+          if (options = class_options(node).first)
+            append_options(classes, options)
+            corrector.replace(options, classes.to_s)
+          else
+            corrector.insert_after(node.first_argument,
+                                   keyword_argument_class(classes))
+          end
+        end
+
+        def append_options(classes, options)
+          classes << options.value if options.str_type?
+          options.each_value { |v| classes << v.value } if options.array_type?
+        end
+
+        def keyword_argument_class(classes)
+          value = classes.size > 1 ? classes.to_s : "'#{classes.first}'"
+          ", class: #{value}"
         end
 
         def replaced_arguments(arg, id)

--- a/lib/rubocop/cop/capybara/specific_matcher.rb
+++ b/lib/rubocop/cop/capybara/specific_matcher.rb
@@ -46,8 +46,7 @@ module RuboCop
           first_argument(node) do |arg|
             next unless (matcher = specific_matcher(arg))
             next if CssSelector.multiple_selectors?(arg)
-            next unless CapybaraHelp.specific_option?(node, arg, matcher)
-            next unless CapybaraHelp.specific_pseudo_classes?(arg)
+            next unless replaceable?(node, arg, matcher)
 
             add_offense(node, message: message(node, matcher))
           end
@@ -58,6 +57,18 @@ module RuboCop
         def specific_matcher(arg)
           splitted_arg = arg[/^\w+/, 0]
           SPECIFIC_MATCHER[splitted_arg]
+        end
+
+        def replaceable?(node, arg, matcher)
+          replaceable_attributes?(arg) &&
+            CapybaraHelp.replaceable_option?(node, arg, matcher) &&
+            CapybaraHelp.replaceable_pseudo_classes?(arg)
+        end
+
+        def replaceable_attributes?(selector)
+          CapybaraHelp.replaceable_attributes?(
+            CssSelector.attributes(selector)
+          )
         end
 
         def message(node, matcher)

--- a/spec/rubocop/cop/capybara/mixin/css_selector_spec.rb
+++ b/spec/rubocop/cop/capybara/mixin/css_selector_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Capybara::CssSelector do
+  describe 'CssSelector.id' do
+    context 'when string whose argument begins with `#`' do
+      it 'returns id string' do
+        expect(described_class.id('#some-id')).to eq 'some-id'
+        expect(described_class.id('#some-id.cls')).to eq 'some-id'
+      end
+
+      it 'returns id string when contain `\`' do
+        expect(described_class.id('#some-id\.id')).to eq 'some-id\\.id'
+      end
+    end
+
+    context 'when string whose argument not begins with `#`' do
+      it 'returns nil' do
+        expect(described_class.id('some-element')).to be_nil
+        expect(described_class.id('.some-cls')).to be_nil
+      end
+    end
+  end
+
+  describe 'CssSelector.id?' do
+    context 'when string whose argument begins with `#`' do
+      it 'returns true' do
+        expect(described_class.id?('#some-id')).to be true
+        expect(described_class.id?('#some-id.cls')).to be true
+      end
+    end
+
+    context 'when string whose argument not begins with `#`' do
+      it 'returns false' do
+        expect(described_class.id?('some-element')).to be false
+        expect(described_class.id?('.some-cls')).to be false
+      end
+    end
+  end
+
+  describe 'CssSelector.classes' do
+    context 'when string whose argument contains `.`' do
+      it 'returns class name array when class string specified one' do
+        expect(described_class.classes('.some-cls')).to match ['some-cls']
+        expect(described_class.classes('h1#foo.bar')).to match ['bar']
+      end
+
+      it 'returns class name array when class string specified more than one' do
+        expect(described_class.classes('.cls1.cls2')).to match %w[cls1 cls2]
+        expect(described_class.classes('h2.cls1.cls2')).to match %w[cls1 cls2]
+      end
+    end
+
+    context 'when string whose argument not contains `.`' do
+      it 'returns empty array' do
+        expect(described_class.classes('some-element')).to match []
+        expect(described_class.classes('#some-id')).to match []
+      end
+    end
+  end
+
+  describe 'CssSelector.attribute?' do
+    it 'returns true when string starting with `[`' do
+      expect(described_class.attribute?('[attribute]')).to be true
+    end
+
+    it 'returns false when string not starting with `[`' do
+      expect(described_class.attribute?('attribute')).to be false
+    end
+  end
+
+  describe 'CssSelector.attributes' do
+    it 'returns attributes hash when specify attributes' do
+      expect(described_class.attributes('a[foo-bar_baz]')).to eq(
+        'foo-bar_baz' => nil
+      )
+      expect(described_class.attributes('table[foo=bar]')).to eq(
+        'foo' => "'bar'"
+      )
+    end
+
+    it 'returns attributes hash when specify multiple attributes' do
+      expect(described_class.attributes('button[foo][bar=baz]')).to eq(
+        'foo' => nil, 'bar' => "'baz'"
+      )
+    end
+
+    it 'returns attributes hash when specify nested attributes' do
+      expect(described_class.attributes('[foo="bar[baz]"]')).to eq(
+        'foo' => "'bar[baz]'"
+      )
+    end
+
+    it 'returns empty hash when specify not include attributes' do
+      expect(described_class.attributes('h1.cls#id')).to eq({})
+    end
+  end
+
+  describe 'CssSelector.pseudo_classes' do
+    it 'returns pseudo class array when include pseudo classes' do
+      expect(
+        described_class.pseudo_classes('button:not([disabled])')
+      ).to match ['not()']
+      expect(
+        described_class.pseudo_classes('a:enabled:not([valid])')
+      ).to match ['enabled', 'not()']
+    end
+
+    it 'returns empty array when not include pseudo classes' do
+      expect(described_class.pseudo_classes('button')).to match []
+    end
+  end
+
+  describe 'CssSelector.multiple_selectors?' do
+    it 'returns true when space-separated selectors' do
+      expect(described_class.multiple_selectors?('a.cls b#id')).to be true
+    end
+
+    it 'returns true when selectors separated by `>`' do
+      expect(described_class.multiple_selectors?('a.cls>b#id')).to be true
+    end
+
+    it 'returns true when selectors separated by `,`' do
+      expect(described_class.multiple_selectors?('a.cls,b#id')).to be true
+    end
+
+    it 'returns true when selectors separated by `+`' do
+      expect(described_class.multiple_selectors?('a.cls+b#id')).to be true
+    end
+
+    it 'returns true when selectors separated by `~`' do
+      expect(described_class.multiple_selectors?('a.cls~b#id')).to be true
+    end
+
+    it 'returns false when single selector' do
+      expect(described_class.multiple_selectors?('a.cls')).to be false
+      expect(described_class.multiple_selectors?('a.cls\>b')).to be false
+    end
+  end
+
+  describe 'CssSelector.normalize_value' do
+    it 'returns true when "true"' do
+      expect(described_class.normalize_value('true')).to be true
+    end
+
+    it 'returns false when "false"' do
+      expect(described_class.normalize_value('false')).to be false
+    end
+
+    it 'returns nil when nil' do
+      expect(described_class.normalize_value(nil)).to be_nil
+    end
+
+    it "returns \"'string'\" when 'string'" do
+      expect(described_class.normalize_value('foo')).to eq "'foo'"
+    end
+  end
+end

--- a/spec/rubocop/cop/capybara/specific_actions_spec.rb
+++ b/spec/rubocop/cop/capybara/specific_actions_spec.rb
@@ -13,8 +13,6 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificActions, :config do
     expect_offense(<<~RUBY)
       find('a', href: 'http://example.com').click
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_link` over `find('a').click`.
-      find("a[href]").click
-      ^^^^^^^^^^^^^^^^^^^^^ Prefer `click_link` over `find('a').click`.
       find("a[href='http://example.com']").click
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_link` over `find('a').click`.
     RUBY
@@ -52,7 +50,7 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificActions, :config do
     RUBY
   end
 
-  it 'registers an offense when using find and click aciton when ' \
+  it 'registers an offense when using find and click actions when ' \
      'first argument is multiple selector ` `' do
     expect_offense(<<~RUBY)
       find('div button').click
@@ -60,7 +58,7 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificActions, :config do
     RUBY
   end
 
-  it 'does not register an offense for find and click aciton when ' \
+  it 'does not register an offense for find and click actions when ' \
      'first argument is multiple selector `,`' do
     expect_no_offenses(<<-RUBY)
       find('button,a').click
@@ -68,7 +66,7 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificActions, :config do
     RUBY
   end
 
-  it 'does not register an offense for find and click aciton when ' \
+  it 'does not register an offense for find and click actions when ' \
      'first argument is multiple selector `>`' do
     expect_no_offenses(<<-RUBY)
       find('button>a').click
@@ -76,7 +74,7 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificActions, :config do
     RUBY
   end
 
-  it 'does not register an offense for find and click aciton when ' \
+  it 'does not register an offense for find and click actions when ' \
      'first argument is multiple selector `+`' do
     expect_no_offenses(<<-RUBY)
       find('button+a').click
@@ -84,7 +82,7 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificActions, :config do
     RUBY
   end
 
-  it 'does not register an offense for find and click aciton when ' \
+  it 'does not register an offense for find and click actions when ' \
      'first argument is multiple selector `~`' do
     expect_no_offenses(<<-RUBY)
       find('button~a').click
@@ -92,25 +90,18 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificActions, :config do
     RUBY
   end
 
-  %i[above below left_of right_of near count minimum maximum between
-     text id class style visible obscured exact exact_text normalize_ws
-     match wait filter_set focused disabled name value
-     title type].each do |attr|
+  %i[id class style disabled name value title type].each do |attr|
     it 'registers an offense for abstract action when ' \
        "first argument is element with replaceable attributes #{attr} " \
        'for `click_button`' do
       expect_offense(<<-RUBY, attr: attr)
         find("button[#{attr}=foo]").click
         ^^^^^^^^^^^^^^{attr}^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
-        find("button[#{attr}]").click
-        ^^^^^^^^^^^^^^{attr}^^^^^^^^^ Prefer `click_button` over `find('button').click`.
       RUBY
     end
   end
 
-  %i[above below left_of right_of near count minimum maximum between text id
-     class style visible obscured exact exact_text normalize_ws match wait
-     filter_set focused alt title download].each do |attr|
+  %i[id class style alt title download].each do |attr|
     it 'does not register an offense for abstract action when ' \
        "first argument is element with replaceable attributes #{attr} " \
        'for `click_link` without `href`' do
@@ -124,10 +115,8 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificActions, :config do
        "first argument is element with replaceable attributes #{attr} " \
        'for `click_link` with attribute `href`' do
       expect_offense(<<-RUBY, attr: attr)
-        find("a[#{attr}=foo][href]").click
-        ^^^^^^^^^{attr}^^^^^^^^^^^^^^^^^^^ Prefer `click_link` over `find('a').click`.
-        find("a[#{attr}][href='http://example.com']").click
-        ^^^^^^^^^{attr}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_link` over `find('a').click`.
+        find("a[#{attr}=foo][href='http://example.com']").click
+        ^^^^^^^^^{attr}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_link` over `find('a').click`.
       RUBY
     end
 
@@ -137,8 +126,8 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificActions, :config do
       expect_offense(<<-RUBY, attr: attr)
         find("a[#{attr}=foo]", href: 'http://example.com').click
         ^^^^^^^^^{attr}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_link` over `find('a').click`.
-        find("a[#{attr}]", text: 'foo', href: 'http://example.com').click
-        ^^^^^^^^^{attr}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_link` over `find('a').click`.
+        find("a[#{attr}=foo]", text: 'foo', href: 'http://example.com').click
+        ^^^^^^^^^{attr}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_link` over `find('a').click`.
       RUBY
     end
   end
@@ -146,37 +135,42 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificActions, :config do
   it 'registers an offense when using abstract action with ' \
      'first argument is element with multiple replaceable attributes' do
     expect_offense(<<-RUBY)
-      find('button[disabled][name="foo"]', exact_text: 'foo').click
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
+      find('button[disabled=true][name="foo"]', exact_text: 'foo').click
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
     RUBY
   end
 
   it 'registers an offense when using abstract action with state' do
     expect_offense(<<-RUBY)
-      find('button[disabled]', exact_text: 'foo').click
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
+      find('button[disabled=false]', exact_text: 'foo').click
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
     RUBY
   end
 
   it 'registers an offense when using abstract action with ' \
      'first argument is element with replaceable pseudo-classes' do
     expect_offense(<<-RUBY)
-      find('button:not([disabled])', exact_text: 'bar').click
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
-      find('button:not([disabled][visible])').click
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
+      find('button:not([disabled=true])', exact_text: 'bar').click
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
     RUBY
   end
 
   it 'registers an offense when using abstract action with ' \
      'first argument is element with multiple replaceable pseudo-classes' do
     expect_offense(<<-RUBY)
-      find('button:not([disabled]):enabled').click
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
+      find('button:not([disabled=true]):enabled').click
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
       find('button:not([disabled=false]):disabled').click
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
-      find('button:not([disabled]):not([disabled])').click
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
+    RUBY
+  end
+
+  it 'does not register an offense when using abstract action with' \
+     'first argument is element with not replaceable attributes' do
+    expect_no_offenses(<<-RUBY)
+      find('button[disabled]').click
+      find('button[id=some-id][disabled]').click
+      find('button[visible]').click
     RUBY
   end
 
@@ -184,21 +178,21 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificActions, :config do
      'first argument is element with replaceable pseudo-classes' \
      'and not boolean attributes' do
     expect_no_offenses(<<-RUBY)
-      find('button:not([name="foo"][disabled])').click
+      find('button:not([name="foo"][disabled=true])').click
     RUBY
   end
 
   it 'does not register an offense when using abstract action with ' \
      'first argument is element with multiple nonreplaceable pseudo-classes' do
     expect_no_offenses(<<-RUBY)
-      find('button:first-of-type:not([disabled])').click
+      find('button:first-of-type:not([disabled=true])').click
     RUBY
   end
 
   it 'does not register an offense for abstract action when ' \
      'first argument is element with nonreplaceable attributes' do
     expect_no_offenses(<<-RUBY)
-      find('button[data-disabled]').click
+      find('button[data-disabled=true]').click
       find('button[foo=bar]').click
       find('button[foo-bar=baz]', exact_text: 'foo').click
     RUBY
@@ -207,15 +201,15 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificActions, :config do
   it 'does not register an offense for abstract action when ' \
      'first argument is element with multiple nonreplaceable attributes' do
     expect_no_offenses(<<-RUBY)
-      find('button[disabled][foo]').click
-      find('button[foo][disabled]').click
-      find('button[foo][disabled][bar]').click
-      find('button[disabled][foo=bar]').click
-      find('button[disabled=foo][bar]', exact_text: 'foo').click
+      find('button[disabled=true][foo=bar]').click
+      find('button[foo=bar][disabled=true]').click
+      find('button[foo=bar][disabled=true][bar=baz]').click
+      find('button[disabled=true][foo=bar]').click
+      find('button[disabled=foo][bar=bar]', exact_text: 'foo').click
     RUBY
   end
 
-  it 'does not register an offense for find and click aciton when ' \
+  it 'does not register an offense for find and click actions when ' \
      'first argument is not a replaceable element' do
     expect_no_offenses(<<-RUBY)
       find('article').click
@@ -223,7 +217,7 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificActions, :config do
     RUBY
   end
 
-  it 'does not register an offense for find and click aciton when ' \
+  it 'does not register an offense for find and click actions when ' \
      'first argument is not an element' do
     expect_no_offenses(<<-RUBY)
       find('.a').click

--- a/spec/rubocop/cop/capybara/specific_finders_spec.rb
+++ b/spec/rubocop/cop/capybara/specific_finders_spec.rb
@@ -23,6 +23,87 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificFinders, :config do
     RUBY
   end
 
+  it 'registers an offense when using `find` with id and class' do
+    expect_offense(<<~RUBY)
+      find('#some-id.some-cls')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id', class: 'some-cls')
+    RUBY
+  end
+
+  it 'registers an offense when using `find` with id include `\.`' do
+    expect_offense(<<~RUBY)
+      find('#some-id\\.some-cls')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+      find('#some-id\\>some-cls')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+      find('#some-id\\,some-cls')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+      find('#some-id\\+some-cls')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+      find('#some-id\\~some-cls')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id.some-cls')
+      find_by_id('some-id>some-cls')
+      find_by_id('some-id,some-cls')
+      find_by_id('some-id+some-cls')
+      find_by_id('some-id~some-cls')
+    RUBY
+  end
+
+  it 'registers an offense when using `find` with multiple classes' do
+    expect_offense(<<~RUBY)
+      find('#some-id.some-cls.other-cls')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id', class: ["some-cls", "other-cls"])
+    RUBY
+  end
+
+  it 'registers an offense when using `find` with multiple classes ' \
+     "and class: 'other-cls'" do
+    expect_offense(<<~RUBY)
+      find('#some-id.some-cls', class: 'other-cls')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id', class: ["some-cls", "other-cls"])
+    RUBY
+  end
+
+  it 'registers an offense when using `find` with multiple classes ' \
+     "and class: ['other-cls1', 'other-cls2']" do
+    expect_offense(<<~RUBY)
+      find('#some-id.some-cls', class: ['other-cls1', 'other-cls2'])
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id', class: ["some-cls", "other-cls1", "other-cls2"])
+    RUBY
+  end
+
+  it 'registers an offense when using `find` with multiple classes ' \
+     "and exact_text: 'foo', class: 'other-cls'" do
+    expect_offense(<<~RUBY)
+      find('#some-id.some-cls', exact_text: 'foo', class: 'other-cls')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id', exact_text: 'foo', class: ["some-cls", "other-cls"])
+    RUBY
+  end
+
   it 'registers an offense when using `find` and other args' do
     expect_offense(<<~RUBY)
       find('#some-id', exact_text: 'foo')
@@ -64,24 +145,42 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificFinders, :config do
     expect_offense(<<~RUBY)
       find('[id=some-id]')
       ^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
-      find('[visible][id=some-id]')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
-      find('[id=some-id][class=some-cls][focused]')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
     RUBY
 
     expect_correction(<<~RUBY)
       find_by_id('some-id')
-      find_by_id('some-id', visible: true)
-      find_by_id('some-id', class: 'some-cls', focused: true)
+    RUBY
+  end
+
+  it 'registers an offense when using `find ' \
+     'with argument is attribute specified id surrounded by quotation' do
+    expect_offense(<<~RUBY)
+      find('[id="foo"]')
+      ^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+      find('[id="foo[bar]"]')
+      ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('foo')
+      find_by_id('foo[bar]')
     RUBY
   end
 
   it 'does not register an offense when using `find ' \
      'with argument is attribute not specified id' do
     expect_no_offenses(<<~RUBY)
-      find('[visible]')
-      find('[class=some-cls][visible]')
+      find('[id]')
+      find('[disabled=true]')
+      find('[class=some-cls][disabled]')
+    RUBY
+  end
+
+  it 'does not register an offense when using `find ' \
+     'with argument is attribute specified id and class' do
+    expect_no_offenses(<<~RUBY)
+      find('[class=some-cls][id=some-id]')
+      find('[id=some-id][disabled][class=some-cls]')
     RUBY
   end
 
@@ -120,6 +219,23 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificFinders, :config do
       find('#some-id>h1')
       find('#some-id,h2')
       find('#some-id+option')
+    RUBY
+  end
+
+  it 'does not register an offense when using `find` ' \
+     'with id and attribute' do
+    expect_no_offenses(<<~RUBY)
+      find('#foo[hidden]')
+      find('#foo[class="some-cls"]')
+    RUBY
+  end
+
+  it 'does not register an offense when using `find` ' \
+     'with id and pseudo class' do
+    expect_no_offenses(<<~RUBY)
+      find('#foo:enabled')
+      find('#foo:not(:disabled)')
+      find('#foo:is(:enabled,:checked)')
     RUBY
   end
 end

--- a/spec/rubocop/cop/capybara/specific_matcher_spec.rb
+++ b/spec/rubocop/cop/capybara/specific_matcher_spec.rb
@@ -78,25 +78,18 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificMatcher do
     RUBY
   end
 
-  %i[above below left_of right_of near count minimum maximum between
-     text id class style visible obscured exact exact_text normalize_ws
-     match wait filter_set focused disabled name value
-     title type].each do |attr|
+  %i[id class style disabled name value title type].each do |attr|
     it 'registers an offense for abstract matcher when ' \
        "first argument is element with replaceable attributes #{attr} " \
        'for `have_button`' do
       expect_offense(<<-RUBY, attr: attr)
         expect(page).to have_css("button[#{attr}=foo]")
                         ^^^^^^^^^^^^^^^^^^{attr}^^^^^^^ Prefer `have_button` over `have_css`.
-        expect(page).to have_css("button[#{attr}]")
-                        ^^^^^^^^^^^^^^^^^^{attr}^^^ Prefer `have_button` over `have_css`.
       RUBY
     end
   end
 
-  %i[above below left_of right_of near count minimum maximum between text id
-     class style visible obscured exact exact_text normalize_ws match wait
-     filter_set focused alt title download].each do |attr|
+  %i[id class style alt title download].each do |attr|
     it 'does not register an offense for abstract matcher when ' \
        "first argument is element with replaceable attributes #{attr} " \
        'for `have_link` without `href`' do
@@ -111,10 +104,8 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificMatcher do
        "first argument is element with replaceable attributes #{attr} " \
        'for `have_link` with attribute `href`' do
       expect_offense(<<-RUBY, attr: attr)
-        expect(page).to have_css("a[#{attr}=foo][href]")
-                        ^^^^^^^^^^^^^{attr}^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
-        expect(page).to have_css("a[#{attr}][href='http://example.com']")
-                        ^^^^^^^^^^^^^{attr}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
+        expect(page).to have_css("a[#{attr}=foo][href='http://example.com']")
+                        ^^^^^^^^^^^^^{attr}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
       RUBY
     end
 
@@ -124,8 +115,8 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificMatcher do
       expect_offense(<<-RUBY, attr: attr)
         expect(page).to have_css("a[#{attr}=foo]", href: 'http://example.com')
                         ^^^^^^^^^^^^^{attr}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
-        expect(page).to have_css("a[#{attr}]", text: 'foo', href: 'http://example.com')
-                        ^^^^^^^^^^^^^{attr}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
+        expect(page).to have_css("a[#{attr}=foo]", text: 'foo', href: 'http://example.com')
+                        ^^^^^^^^^^^^^{attr}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
       RUBY
     end
   end
@@ -134,58 +125,40 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificMatcher do
      'first argument is element with replaceable attributes href ' \
      'for `have_link`' do
     expect_offense(<<-RUBY)
-      expect(page).to have_css("a[href]")
-                      ^^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
       expect(page).to have_css("a[href='http://example.com']")
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
     RUBY
   end
 
-  %i[above below left_of right_of near count minimum maximum between
-     text id class style visible obscured exact exact_text normalize_ws
-     match wait filter_set focused caption with_cols cols with_rows
-     rows].each do |attr|
+  %i[id class style cols rows].each do |attr|
     it 'registers an offense for abstract matcher when ' \
        "first argument is element with replaceable attributes #{attr} " \
        'for `have_table`' do
       expect_offense(<<-RUBY, attr: attr)
         expect(page).to have_css("table[#{attr}=foo]")
                         ^^^^^^^^^^^^^^^^^{attr}^^^^^^^ Prefer `have_table` over `have_css`.
-        expect(page).to have_css("table[#{attr}]")
-                        ^^^^^^^^^^^^^^^^^{attr}^^^ Prefer `have_table` over `have_css`.
       RUBY
     end
   end
 
-  %i[above below left_of right_of near count minimum maximum between
-     text id class style visible obscured exact exact_text normalize_ws
-     match wait filter_set focused disabled name placeholder options
-     enabled_options disabled_options selected with_selected
-     multiple with_options].each do |attr|
+  %i[id class style disabled name placeholder selected multiple].each do |attr|
     it 'registers an offense for abstract matcher when ' \
        "first argument is element with replaceable attributes #{attr} " \
        'for `have_select`' do
       expect_offense(<<-RUBY, attr: attr)
         expect(page).to have_css("select[#{attr}=foo]")
                         ^^^^^^^^^^^^^^^^^^{attr}^^^^^^^ Prefer `have_select` over `have_css`.
-        expect(page).to have_css("select[#{attr}]")
-                        ^^^^^^^^^^^^^^^^^^{attr}^^^ Prefer `have_select` over `have_css`.
       RUBY
     end
   end
 
-  %i[above below left_of right_of near count minimum maximum between
-     text id class style visible obscured exact exact_text normalize_ws
-     match wait filter_set checked unchecked disabled valid name
-     placeholder validation_message ].each do |attr|
+  %i[id class style checked disabled name placeholder].each do |attr|
     it 'registers an offense for abstract matcher when ' \
        "first argument is element with replaceable attributes #{attr} " \
        'for `have_field`' do
       expect_offense(<<-RUBY, attr: attr)
         expect(page).to have_css("input[#{attr}=foo]")
                         ^^^^^^^^^^^^^^^^^^{attr}^^^^^^ Prefer `have_field` over `have_css`.
-        expect(page).to have_css("input[#{attr}]")
-                        ^^^^^^^^^^^^^^^^^^{attr}^^ Prefer `have_field` over `have_css`.
       RUBY
     end
   end
@@ -193,43 +166,41 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificMatcher do
   it 'registers an offense when using abstract matcher with ' \
      'first argument is element with multiple replaceable attributes' do
     expect_offense(<<-RUBY)
-      expect(page).to have_css('button[disabled][name="foo"]', exact_text: 'foo')
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+      expect(page).to have_css('button[disabled=true][name="foo"]', exact_text: 'foo')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
     RUBY
   end
 
   it 'registers an offense when using abstract matcher with state' do
     expect_offense(<<-RUBY)
-      expect(page).to have_css('button[disabled]', exact_text: 'foo')
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+      expect(page).to have_css('button[disabled=true]', exact_text: 'foo')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
     RUBY
   end
 
   it 'registers an offense when using abstract matcher with ' \
      'first argument is element with replaceable pseudo-classes' do
     expect_offense(<<-RUBY)
-      expect(page).to have_css('button:not([disabled])', exact_text: 'bar')
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
-      expect(page).to have_css('button:not([disabled][visible])')
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+      expect(page).to have_css('button:not([disabled=true])', exact_text: 'bar')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
     RUBY
   end
 
   it 'registers an offense when using abstract matcher with ' \
      'first argument is element with multiple replaceable pseudo-classes' do
     expect_offense(<<-RUBY)
-      expect(page).to have_css('button:not([disabled]):enabled')
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+      expect(page).to have_css('button:not([disabled=true]):enabled')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
       expect(page).to have_css('button:not([disabled=false]):disabled')
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
-      expect(page).to have_css('button:not([disabled]):not([disabled])')
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
-      expect(page).to have_css('input:not([unchecked]):checked')
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_field` over `have_css`.
-      expect(page).to have_css('input:not([unchecked=false]):unchecked')
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_field` over `have_css`.
-      expect(page).to have_css('input:not([unchecked]):not([unchecked])')
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_field` over `have_css`.
+      expect(page).to have_css('button:not([disabled=true]):not([disabled=true])')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+      expect(page).to have_css('input:not([checked=false]):checked')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_field` over `have_css`.
+      expect(page).to have_css('input:not([checked=false]):unchecked')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_field` over `have_css`.
+      expect(page).to have_css('input:not([checked=true]):not([checked=true])')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_field` over `have_css`.
     RUBY
   end
 
@@ -251,6 +222,7 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificMatcher do
   it 'does not register an offense for abstract matcher when ' \
      'first argument is element with nonreplaceable attributes' do
     expect_no_offenses(<<-RUBY)
+      expect(page).to have_css('button[disabled]')
       expect(page).to have_css('button[data-disabled]')
       expect(page).to have_css('button[foo=bar]')
       expect(page).to have_css('button[foo-bar=baz]', exact_text: 'foo')
@@ -260,10 +232,10 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificMatcher do
   it 'does not register an offense for abstract matcher when ' \
      'first argument is element with multiple nonreplaceable attributes' do
     expect_no_offenses(<<-RUBY)
-      expect(page).to have_css('button[disabled][foo]')
-      expect(page).to have_css('button[foo][disabled]')
-      expect(page).to have_css('button[foo][disabled][bar]')
-      expect(page).to have_css('button[disabled][foo=bar]')
+      expect(page).to have_css('button[disabled=true][foo]')
+      expect(page).to have_css('button[foo][disabled=true]')
+      expect(page).to have_css('button[foo][disabled=true][bar]')
+      expect(page).to have_css('button[disabled=true][foo=bar]')
       expect(page).to have_css('button[disabled=foo][bar]', exact_text: 'foo')
     RUBY
   end


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-capybara/issues/4

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).