### PR TITLE
Fix errors in documentation for file paths to be inspected

### DIFF
--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -38,24 +38,35 @@ RuboCop::RakeTask.new do |task|
 end
 ----
 
-== Inspecting files that don't end with `_spec.rb`
+== File paths to be inspected
 
-By default, `rubocop-capybara` only inspects code within paths ending in `_spec.rb` or including `spec/`. You can override this setting in your config file by setting `Include`:
-
-[source,yaml]
-----
-# Inspect files in `test/` directory
-Capybara:
-  Include:
-    - '**/test/**/*'
-----
+By default, `rubocop-capybara` only inspects code in files whose paths match the following regular expression.
 
 [source,yaml]
 ----
-# Inspect only files ending with `_test.rb`
 Capybara:
   Include:
-    - '**/*_test.rb'
+    - ’**/*_spec.rb’
+    - ’**/spec/**/*’
+    - ’**/test/**/*’
+----
+
+You can override this setting in your config file by setting `Include`:
+
+[source,yaml]
+----
+# Inspect files in `inspection/` directory
+Capybara:
+  Include:
+    - '**/inspection/**/*'
+----
+
+[source,yaml]
+----
+# Inspect only files ending with `_inspection.rb`
+Capybara:
+  Include:
+    - '**/*_inspection.rb'
 ----
 
 NOTE: Please keep in mind that merge mode for `Include` is set to override the default settings, so if you intend to add a path while keeping the default paths, you should include the default `Include` paths in your configuration.


### PR DESCRIPTION
Currently, `**/test/**/*` is also inspected by `rubocop-capybara`, so I modified it accordingly.

Ref: https://github.com/rubocop/rubocop-capybara/blob/10e2d89cf876888dcca3c473a7c69cc6b5cb93cc/config/default.yml#L8
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [x] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).