### PR TITLE
Add path to support cucumber in Include

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -6,6 +6,8 @@ Capybara:
     - "**/*_spec.rb"
     - "**/spec/**/*"
     - "**/test/**/*"
+    - "**/*_steps.rb"
+    - "**/features/step_definitions/**/*"
 
 Capybara/CurrentPathExpectation:
   Description: Checks that no expectations are set on Capybara's `current_path`.

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -46,9 +46,11 @@ By default, `rubocop-capybara` only inspects code in files whose paths match the
 ----
 Capybara:
   Include:
-    - ’**/*_spec.rb’
-    - ’**/spec/**/*’
-    - ’**/test/**/*’
+    - '**/*_spec.rb'
+    - '**/spec/**/*'
+    - '**/test/**/*'
+    - '**/*_steps.rb'
+    - '**/features/step_definitions/**/*'
 ----
 
 You can override this setting in your config file by setting `Include`:


### PR DESCRIPTION
In this PR we are going to add the file path where cucumber test files are located to the default Include.

Ref: https://github.com/cucumber/cucumber-ruby#initialization

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [x] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
