### PR TITLE
Fix an incorrect autocorrect for `Capybara/PathExpectation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Edge (Unreleased)
 
+- Fix an incorrect autocorrect for `Capybara/PathExpectation`. ([@ydah])
+
 ## 2.17.0 (2022-12-29)
 
 - Extracted from `rubocop-rspec` into a separate repository for easier use with Minitest/Cucumber. ([@pirj])

--- a/lib/rubocop/cop/capybara/current_path_expectation.rb
+++ b/lib/rubocop/cop/capybara/current_path_expectation.rb
@@ -110,7 +110,9 @@ module RuboCop
         def add_ignore_query_options(corrector, node)
           expectation_node = node.parent.last_argument
           expectation_last_child = expectation_node.children.last
-          return if %i[regexp str].include?(expectation_last_child.type)
+          return if %i[
+            regexp str dstr xstr
+          ].include?(expectation_last_child.type)
 
           corrector.insert_after(
             expectation_last_child,

--- a/spec/rubocop/cop/capybara/current_path_expectation_spec.rb
+++ b/spec/rubocop/cop/capybara/current_path_expectation_spec.rb
@@ -12,6 +12,31 @@ RSpec.describe RuboCop::Cop::Capybara::CurrentPathExpectation do
     RUBY
   end
 
+  it 'flags violations for `expect(current_path)` with ' \
+     'a multi-line string argument' do
+    expect_offense(<<~'RUBY')
+      expect(current_path).to eq "/callback" \
+      ^^^^^^ Do not set an RSpec expectation on `current_path` in Capybara feature specs - instead, use the `have_current_path` matcher on `page`
+                                  "/foo"
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      expect(page).to have_current_path "/callback" \
+                                  "/foo"
+    RUBY
+  end
+
+  it 'flags violations for `expect(current_path)` with a `command`' do
+    expect_offense(<<~'RUBY')
+      expect(current_path).to eq `pwd`
+      ^^^^^^ Do not set an RSpec expectation on `current_path` in Capybara feature specs - instead, use the `have_current_path` matcher on `page`
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      expect(page).to have_current_path `pwd`
+    RUBY
+  end
+
   it 'flags violations for `expect(page.current_path)`' do
     expect_offense(<<-RUBY)
       expect(page.current_path).to eq("/callback")


### PR DESCRIPTION
This PR is fix an incorrect autocorrect for `Capybara/PathExpectation`.


```diff
-expect(page).to have_current_path `pwd`
+expect(page).to have_current_path `pwd`, ignore_query: true

expect(page).to have_current_path "/callback" \
-                            "/foo"
+                            "/foo", ignore_query: true
```
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).