### PR TITLE
Apply concurrency for GHA workflow `pull_requests` events only

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -2,7 +2,7 @@ name: CodeSpell
 on:
   - pull_request
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
   codespell:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,7 +2,7 @@ name: Linting
 on:
   - pull_request
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
   yamllint:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Same as: https://github.com/rubocop/rubocop-rspec/pull/1544 https://github.com/rubocop/rubocop/pull/11414

The following are included as keys to the group.
`${{ github.head_ref || github.run_id }}`

This allows concurrency to work only with Push to PullRequest, and cancels all but the most recent push for successive pushes; for merge commits, in other words push events, `${{ github.run_id }}` is used, so The cancellation is not enforced because it is always a unique group.

This eliminates the problem of consecutive Pushes being cancelled at the time of release.

![release](https://user-images.githubusercontent.com/13041216/211700533-cb01c051-dc8d-4889-8276-327c96bf4755.png)

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).