### PR TITLE
Bump version to v2.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Edge (Unreleased)
 
+## 2.17.1 (2023-02-13)
+
 - Fix an incorrect autocorrect for `Capybara/CurrentPathExpectation`. ([@ydah])
 - Fix a false negative for `Capybara/CurrentPathExpectation` when using `match`. ([@ydah])
 - Fix a false positive and incorrect autocorrect for `Capybara/SpecificActions`, `Capybara/SpecificFinders` and `Capybara/SpecificMatcher`. ([@ydah])

--- a/lib/rubocop/capybara/version.rb
+++ b/lib/rubocop/capybara/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Capybara
     # Version information for the Capybara RuboCop plugin.
     module Version
-      STRING = '2.17.0'
+      STRING = '2.17.1'
     end
   end
 end


### PR DESCRIPTION
A month has passed since the [last release](https://github.com/rubocop/rubocop-capybara/pull/2), so let's move on to the next version.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).