### PR TITLE
Correct offenses for `InternalAffairs`

### DIFF
--- a/lib/rubocop/cop/capybara/specific_actions.rb
+++ b/lib/rubocop/cop/capybara/specific_actions.rb
@@ -75,7 +75,7 @@ module RuboCop
         end
 
         def offense_range(node, receiver)
-          receiver.loc.selector.with(end_pos: node.loc.expression.end_pos)
+          receiver.loc.selector.with(end_pos: node.source_range.end_pos)
         end
 
         def message(action, selector)

--- a/lib/rubocop/cop/capybara/specific_finders.rb
+++ b/lib/rubocop/cop/capybara/specific_finders.rb
@@ -68,7 +68,7 @@ module RuboCop
         def register_offense(node, id, classes = [])
           add_offense(offense_range(node)) do |corrector|
             corrector.replace(node.loc.selector, 'find_by_id')
-            corrector.replace(node.first_argument.loc.expression,
+            corrector.replace(node.first_argument.source_range,
                               id.delete('\\'))
             unless classes.compact.empty?
               autocorrect_classes(corrector, node, classes)
@@ -117,7 +117,7 @@ module RuboCop
           if node.loc.end
             node.loc.end.end_pos
           else
-            node.loc.expression.end_pos
+            node.source_range.end_pos
           end
         end
       end

--- a/lib/rubocop/cop/capybara/specific_finders.rb
+++ b/lib/rubocop/cop/capybara/specific_finders.rb
@@ -68,7 +68,7 @@ module RuboCop
         def register_offense(node, id, classes = [])
           add_offense(offense_range(node)) do |corrector|
             corrector.replace(node.loc.selector, 'find_by_id')
-            corrector.replace(node.first_argument.source_range,
+            corrector.replace(node.first_argument,
                               id.delete('\\'))
             unless classes.compact.empty?
               autocorrect_classes(corrector, node, classes)


### PR DESCRIPTION
This PR correct offenses for `InternalAffairs/LocationExpression` and `InternalAffairs/RedundantSourceRange`.

```
Offenses:

lib/rubocop/cop/capybara/specific_actions.rb:78:52: C: [Corrected] InternalAffairs/LocationExpression: Use source_range instead.
          receiver.loc.selector.with(end_pos: node.loc.expression.end_pos)
                                                   ^^^^^^^^^^^^^^
lib/rubocop/cop/capybara/specific_finders.rb:71:51: C: [Corrected] InternalAffairs/LocationExpression: Use source_range instead.
            corrector.replace(node.first_argument.loc.expression,
                                                  ^^^^^^^^^^^^^^
lib/rubocop/cop/capybara/specific_finders.rb:120:18: C: [Corrected] InternalAffairs/LocationExpression: Use source_range instead.
            node.loc.expression.end_pos
                 ^^^^^^^^^^^^^^

33 files inspected, 3 offenses detected, 3 offenses corrected
```

```
Offenses:

lib/rubocop/cop/capybara/specific_finders.rb:71:51: C: [Correctable] InternalAffairs/RedundantSourceRange: Remove the redundant source_range.
            corrector.replace(node.first_argument.source_range,
                                                  ^^^^^^^^^^^^

33 files inspected, 1 offense detected, 1 offense autocorrectable
Error: Process completed with exit code 1.
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).