### PR TITLE
Add an option to the actions-codespell configuration to check hidden files

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -14,4 +14,5 @@ jobs:
         uses: codespell-project/actions-codespell@master
         with:
           check_filenames: true
+          check_hidden: true
           ignore_words_file: .codespellignore


### PR DESCRIPTION
How about checking about codespell for hidden files (those starting with ".") as well? 
https://github.com/codespell-project/actions-codespell#parameter-check_hidden

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
