### PR TITLE
Fix a few broken links in docs

### DIFF
--- a/docs/modules/ROOT/pages/cops_capybara.adoc
+++ b/docs/modules/ROOT/pages/cops_capybara.adoc
@@ -15,10 +15,10 @@
 Checks that no expectations are set on Capybara's `current_path`.
 
 The
-https://www.rubydoc.info/github/teamcapybara/capybara/main/Capybara/RSpecMatchers#have_current_path-instance_method[`have_current_path` matcher]
+https://www.rubydoc.info/github/teamcapybara/capybara/master/Capybara/RSpecMatchers#have_current_path-instance_method[`have_current_path` matcher]
 should be used on `page` to set expectations on Capybara's
 current path, since it uses
-https://github.com/teamcapybara/capybara/blob/main/README.md#asynchronous-javascript-ajax-and-friends[Capybara's waiting functionality]
+https://github.com/teamcapybara/capybara/blob/master/README.md#asynchronous-javascript-ajax-and-friends[Capybara's waiting functionality]
 which ensures that preceding actions (like `click_link`) have
 completed.
 

--- a/lib/rubocop/cop/capybara/current_path_expectation.rb
+++ b/lib/rubocop/cop/capybara/current_path_expectation.rb
@@ -6,10 +6,10 @@ module RuboCop
       # Checks that no expectations are set on Capybara's `current_path`.
       #
       # The
-      # https://www.rubydoc.info/github/teamcapybara/capybara/main/Capybara/RSpecMatchers#have_current_path-instance_method[`have_current_path` matcher]
+      # https://www.rubydoc.info/github/teamcapybara/capybara/master/Capybara/RSpecMatchers#have_current_path-instance_method[`have_current_path` matcher]
       # should be used on `page` to set expectations on Capybara's
       # current path, since it uses
-      # https://github.com/teamcapybara/capybara/blob/main/README.md#asynchronous-javascript-ajax-and-friends[Capybara's waiting functionality]
+      # https://github.com/teamcapybara/capybara/blob/master/README.md#asynchronous-javascript-ajax-and-friends[Capybara's waiting functionality]
       # which ensures that preceding actions (like `click_link`) have
       # completed.
       #


### PR DESCRIPTION
I noticed some broken links while browsing the capybara manual ([here](https://docs.rubocop.org/rubocop-capybara/cops_capybara.html#capybaracurrentpathexpectation)). This PR fixes them.

Perhaps capybara's default branch used to be `main`? I'm not sure... but presently it is `master`, and so these links need to be updated.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] ~Added the new cop to `config/default.yml`.~
- [ ] ~The cop is configured as `Enabled: pending` in `config/default.yml`.~
- [ ] ~The cop documents examples of good and bad code.~
- [ ] ~The tests assert both that bad code is reported and that good code is not reported.~
- [ ] ~Set `VersionAdded: "<<next>>"` in `default/config.yml`.~

If you have modified an existing cop's configuration options:

- [ ] ~Set `VersionChanged: "<<next>>"` in `config/default.yml`.~