### PR TITLE
Expand `Capybara/NegationMatcher` to support `have_content`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Edge (Unreleased)
 
 - Fix an offense message for `Capybara/SpecificFinders`. ([@ydah])
+- Expand `Capybara/NegationMatcher` to support `have_content` ([@OskarsEzerins])
 
 ## 2.17.1 (2023-02-13)
 
@@ -49,6 +50,7 @@
 [@bquorning]: https://github.com/bquorning
 [@darhazer]: https://github.com/Darhazer
 [@onumis]: https://github.com/onumis
+[@oskarsezerins]: https://github.com/OskarsEzerins
 [@pirj]: https://github.com/pirj
 [@rspeicher]: https://github.com/rspeicher
 [@timrogers]: https://github.com/timrogers

--- a/lib/rubocop/cop/capybara/negation_matcher.rb
+++ b/lib/rubocop/cop/capybara/negation_matcher.rb
@@ -31,7 +31,7 @@ module RuboCop
         CAPYBARA_MATCHERS = %w[
           selector css xpath text title current_path link button
           field checked_field unchecked_field select table
-          sibling ancestor
+          sibling ancestor content
         ].freeze
         POSITIVE_MATCHERS =
           Set.new(CAPYBARA_MATCHERS) { |element| :"have_#{element}" }.freeze

--- a/spec/rubocop/cop/capybara/negation_matcher_spec.rb
+++ b/spec/rubocop/cop/capybara/negation_matcher_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RuboCop::Cop::Capybara::NegationMatcher, :config do
 
     %i[selector css xpath text title current_path link button
        field checked_field unchecked_field select table
-       sibling ancestor].each do |matcher|
+       sibling ancestor content].each do |matcher|
       it 'registers an offense when using ' \
          '`expect(...).not_to have_#{matcher}`' do
         expect_offense(<<~RUBY, matcher: matcher)
@@ -54,7 +54,7 @@ RSpec.describe RuboCop::Cop::Capybara::NegationMatcher, :config do
 
     %i[selector css xpath text title current_path link button
        field checked_field unchecked_field select table
-       sibling ancestor].each do |matcher|
+       sibling ancestor content].each do |matcher|
       it 'registers an offense when using ' \
          '`expect(...).to have_no_#{matcher}`' do
         expect_offense(<<~RUBY, matcher: matcher)


### PR DESCRIPTION
Added `content` to the list of matchers for `Capybara/NegationMatcher`. 
It allows said cop to check for `not_to have_content`, correct it to `to have_no_content` and vice versa.

`have_content` is not included in Capybara list of `have_no_..` matchers but is rather aliased to `have_no_text`. ([source](https://github.com/teamcapybara/capybara/blob/c8d3ff5f9b768428d5b2013931cc92ffa324b88b/lib/capybara/rspec/matchers.rb#L169)). 
I'm not sure if thats perhaps a problem for this PR`s change. Maybe a different approach has to be taken due to above said.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] ~~Updated documentation.~~
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).