### PR TITLE
Fix the issue of blocking merge when making it required

### DIFF
--- a/.github/workflows/mdformat.yml
+++ b/.github/workflows/mdformat.yml
@@ -1,8 +1,6 @@
 name: Mdformat
 on:
   pull_request:
-    paths:
-      - '**/*.md'
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -12,8 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v35
       - name: Mdformat
         uses: ydah/mdformat-action@main
+        if: contains(steps.changed-files.outputs.all_changed_files, '.md')
         with:
           number: true
         env:

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,9 +1,6 @@
 name: Yamllint
 on:
   pull_request:
-    paths:
-      - '**/*.yaml'
-      - '**/*.yml'
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -13,8 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v35
       - name: Yamllint
         uses: karancode/yamllint-github-action@master
+        if: |
+          contains(steps.changed-files.outputs.all_changed_files, '.yml') ||
+          contains(steps.changed-files.outputs.all_changed_files, '.yaml')
         with:
           yamllint_strict: true
           yamllint_format: parsable


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-capybara/pull/39#issuecomment-1509796770
This PR change the control from `paths` to `if`.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
