### PR TITLE
Fix the issue of blocking merge when making it required

### DIFF
--- a/.github/workflows/mdformat.yml
+++ b/.github/workflows/mdformat.yml
@@ -1,8 +1,6 @@
 name: Mdformat
 on:
   pull_request:
-    paths:
-      - '**/*.md'
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,9 +1,6 @@
 name: Yamllint
 on:
   pull_request:
-    paths:
-      - '**/*.yaml'
-      - '**/*.yml'
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
This PR remove filtering by `paths`.

We have made it our policy to have a conversation here and remove control by `paths`.
- https://github.com/rubocop/rubocop-capybara/pull/40#discussion_r1167681129

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
