### PR TITLE
Bump version to v2.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Edge (Unreleased)
 
+## 2.18.0 (2023-04-17)
+
 - Fix an offense message for `Capybara/SpecificFinders`. ([@ydah])
 - Expand `Capybara/NegationMatcher` to support `have_content` ([@OskarsEzerins])
 - Fix an incorrect autocorrect for `Capybara/CurrentPathExpectation` when matcher's argument is a method with a argument and no parentheses. ([@ydah])

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: rubocop-capybara
 title: RuboCop Capybara
-version: ~
+version: '2.18'
 nav:
   - modules/ROOT/nav.adoc

--- a/lib/rubocop/capybara/version.rb
+++ b/lib/rubocop/capybara/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Capybara
     # Version information for the Capybara RuboCop plugin.
     module Version
-      STRING = '2.17.1'
+      STRING = '2.18.0'
     end
   end
 end


### PR DESCRIPTION
A few months have passed since the [last release](https://github.com/rubocop/rubocop-capybara/releases/tag/v2.17.1), so let's move on to the next version.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).