### PR TITLE
Drop Ruby 2.6 runtime support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - "2.6"
           - "2.7"
           - "3.0"
           - "3.1"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ require:
 
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   NewCops: disable
   Exclude:
     - 'vendor/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Edge (Unreleased)
 
+- Drop Ruby 2.6 support. ([@ydah])
+
 ## 2.18.0 (2023-04-21)
 
 - Fix an offense message for `Capybara/SpecificFinders`. ([@ydah])

--- a/rubocop-capybara.gemspec
+++ b/rubocop-capybara.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.version = RuboCop::Capybara::Version::STRING
   spec.platform = Gem::Platform::RUBY
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 2.7.0'
 
   spec.require_paths = ['lib']
   spec.files = Dir[


### PR DESCRIPTION
This PR drops Ruby 2.6 runtime support. The next release will be the time to drop Ruby 2.6 support:

https://www.ruby-lang.org/en/downloads/branches/
https://docs.rubocop.org/rubocop/compatibility.html#support-matrix

Follow up: https://github.com/rubocop/rubocop/pull/11791

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).