### PR TITLE
Update dependency to latest Rubocop 1.50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Edge (Unreleased)
 
+- Update dependency to rubocop 1.50
+
 ## 2.18.0 (2023-04-21)
 
 - Fix an offense message for `Capybara/SpecificFinders`. ([@ydah])

--- a/rubocop-capybara.gemspec
+++ b/rubocop-capybara.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
     'rubygems_mfa_required' => 'true'
   }
 
-  spec.add_runtime_dependency 'rubocop', '~> 1.41'
+  spec.add_runtime_dependency 'rubocop', '~> 1.50'
 end


### PR DESCRIPTION
edit : Hello ! I would like to use Rubocop higher than 1.41. I cant because of this :)

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).