### PR TITLE
Add missing pending rubocop-rspec cops in v2.20.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -123,6 +123,8 @@ Style/RedundantStringEscape:
 
 # Enable pending rubocop-rspec cops.
 
+RSpec/BeEmpty:
+  Enabled: true
 RSpec/BeEq:
   Enabled: true
 RSpec/BeNil:
@@ -131,15 +133,25 @@ RSpec/ChangeByZero:
   Enabled: true
 RSpec/ClassCheck:
   Enabled: true
+RSpec/ContainExactly:
+  Enabled: true
 RSpec/DuplicatedMetadata:
   Enabled: true
 RSpec/ExcessiveDocstringSpacing:
   Enabled: true
 RSpec/IdenticalEqualityAssertion:
   Enabled: true
+RSpec/IndexedLet:
+  Enabled: true
+RSpec/MatchArray:
+  Enabled: true
 RSpec/NoExpectationExample:
   Enabled: true
 RSpec/PendingWithoutReason:
+  Enabled: true
+RSpec/RedundantAround:
+  Enabled: true
+RSpec/SkipBlockInsideExample:
   Enabled: true
 RSpec/SortMetadata:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'rake'
 gem 'rspec', '~> 3.11'
 gem 'rubocop-performance', '~> 1.7'
 gem 'rubocop-rake', '~> 0.6'
-gem 'rubocop-rspec', '~> 2.16.0'
+gem 'rubocop-rspec', '~> 2.20.0'
 gem 'simplecov', '>= 0.19'
 gem 'yard'
 


### PR DESCRIPTION
This PR add missing pending rubocop-rspec cops in v2.20.0.
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).