### PR TITLE
Remove redundant config metadata

### DIFF
--- a/spec/rubocop/cop/capybara/match_style_spec.rb
+++ b/spec/rubocop/cop/capybara/match_style_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Capybara::MatchStyle, :config do
+RSpec.describe RuboCop::Cop::Capybara::MatchStyle do
   it 'registers an offense when using `assert_style`' do
     expect_offense(<<~RUBY)
       page.find(:css, '#first').assert_style(display: 'block')

--- a/spec/rubocop/cop/capybara/negation_matcher_spec.rb
+++ b/spec/rubocop/cop/capybara/negation_matcher_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Capybara::NegationMatcher, :config do
+RSpec.describe RuboCop::Cop::Capybara::NegationMatcher do
   let(:cop_config) { { 'EnforcedStyle' => enforced_style } }
 
   context 'with EnforcedStyle `have_no`' do

--- a/spec/rubocop/cop/capybara/specific_actions_spec.rb
+++ b/spec/rubocop/cop/capybara/specific_actions_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Capybara::SpecificActions, :config do
+RSpec.describe RuboCop::Cop::Capybara::SpecificActions do
   it 'does not register an offense for find and click action when ' \
      'first argument is link' do
     expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/capybara/specific_finders_spec.rb
+++ b/spec/rubocop/cop/capybara/specific_finders_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Capybara::SpecificFinders, :config do
+RSpec.describe RuboCop::Cop::Capybara::SpecificFinders do
   it 'registers an offense when using `find`' do
     expect_offense(<<~RUBY)
       find('#some-id')


### PR DESCRIPTION
Previously, in `rubocop-rspec`, this was needed to have control over "config" shared context
inclusion. We wanted to include ours, but not the one from `rubocop`.

Sibling to https://github.com/rubocop/rubocop-factory_bot/pull/21 and https://github.com/rubocop/rubocop-rspec/pull/1640

Thanks @r7kamura!


**Replace this text with a summary of the changes in your PR. The more detailed you are, the better.**

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).