### PR TITLE
Use U+002d instead of U+2013

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -5,7 +5,7 @@ https://github.com/rubocop/rubocop[RuboCop].
 
 RuboCop Capybara follows the https://docs.rubocop.org/rubocop/versioning.html[RuboCop versioning guide].
 In a nutshell, between major versions new cops are introduced in a special `pending` status.
-That means that they won’t be run unless explicitly told otherwise.
+That means that they won't be run unless explicitly told otherwise.
 RuboCop will warn on start that certain cops are neither explicitly enabled and disabled.
 On a major version release, all `pending` cops are enabled.
 


### PR DESCRIPTION
Follow up: https://github.com/rubocop/rubocop-factory_bot/pull/27

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [x] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
