### PR TITLE
Change to default `EnforcedStyle: have_no` for `Capybara/NegationMatcher` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix a false negative for `RSpec/HaveSelector` when first argument is dstr node. ([@ydah])
 - Add new `Capybara/RedundantWithinFind` cop. ([@ydah])
 - Fix an invalid attributes parse when name with multiple `[]` for `Capybara/SpecificFinders` and `Capybara/SpecificActions` and `Capybara/SpecificMatcher`. ([@ydah])
+- Change to default `EnforcedStyle: have_no` for `Capybara/NegationMatcher` cop. ([@ydah])
 
 ## 2.19.0 (2023-09-20)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -37,7 +37,8 @@ Capybara/NegationMatcher:
   Description: Enforces use of `have_no_*` or `not_to` for negated expectations.
   Enabled: pending
   VersionAdded: '2.14'
-  EnforcedStyle: not_to
+  VersionChanged: "<<next>>"
+  EnforcedStyle: have_no
   SupportedStyles:
     - have_no
     - not_to

--- a/docs/modules/ROOT/pages/cops_capybara.adoc
+++ b/docs/modules/ROOT/pages/cops_capybara.adoc
@@ -170,27 +170,14 @@ expect(page).to match_style(display: 'block')
 | Yes
 | Yes
 | 2.14
-| -
+| <<next>>
 |===
 
 Enforces use of `have_no_*` or `not_to` for negated expectations.
 
 === Examples
 
-==== EnforcedStyle: not_to (default)
-
-[source,ruby]
-----
-# bad
-expect(page).to have_no_selector
-expect(page).to have_no_css('a')
-
-# good
-expect(page).not_to have_selector
-expect(page).not_to have_css('a')
-----
-
-==== EnforcedStyle: have_no
+==== EnforcedStyle: have_no (default)
 
 [source,ruby]
 ----
@@ -201,6 +188,19 @@ expect(page).not_to have_css('a')
 # good
 expect(page).to have_no_selector
 expect(page).to have_no_css('a')
+----
+
+==== EnforcedStyle: not_to
+
+[source,ruby]
+----
+# bad
+expect(page).to have_no_selector
+expect(page).to have_no_css('a')
+
+# good
+expect(page).not_to have_selector
+expect(page).not_to have_css('a')
 ----
 
 === Configurable attributes
@@ -209,7 +209,7 @@ expect(page).to have_no_css('a')
 | Name | Default value | Configurable values
 
 | EnforcedStyle
-| `not_to`
+| `have_no`
 | `have_no`, `not_to`
 |===
 

--- a/lib/rubocop/cop/capybara/negation_matcher.rb
+++ b/lib/rubocop/cop/capybara/negation_matcher.rb
@@ -5,16 +5,7 @@ module RuboCop
     module Capybara
       # Enforces use of `have_no_*` or `not_to` for negated expectations.
       #
-      # @example EnforcedStyle: not_to (default)
-      #   # bad
-      #   expect(page).to have_no_selector
-      #   expect(page).to have_no_css('a')
-      #
-      #   # good
-      #   expect(page).not_to have_selector
-      #   expect(page).not_to have_css('a')
-      #
-      # @example EnforcedStyle: have_no
+      # @example EnforcedStyle: have_no (default)
       #   # bad
       #   expect(page).not_to have_selector
       #   expect(page).not_to have_css('a')
@@ -22,6 +13,15 @@ module RuboCop
       #   # good
       #   expect(page).to have_no_selector
       #   expect(page).to have_no_css('a')
+      #
+      # @example EnforcedStyle: not_to
+      #   # bad
+      #   expect(page).to have_no_selector
+      #   expect(page).to have_no_css('a')
+      #
+      #   # good
+      #   expect(page).not_to have_selector
+      #   expect(page).not_to have_css('a')
       #
       class NegationMatcher < ::RuboCop::Cop::Base
         extend AutoCorrector


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-capybara/issues/57

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

- [x] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
