### PR TITLE
Fix an errors in `Capybara/SpecificFinders` documentation

### DIFF
--- a/docs/modules/ROOT/pages/cops_capybara.adoc
+++ b/docs/modules/ROOT/pages/cops_capybara.adoc
@@ -211,11 +211,10 @@ Checks if there is a more specific finder offered by Capybara.
 ----
 # bad
 find('#some-id')
-find('[visible][id=some-id]')
+find('[id=some-id]')
 
 # good
 find_by_id('some-id')
-find_by_id('some-id', visible: true)
 ----
 
 === References

--- a/lib/rubocop/cop/capybara/specific_finders.rb
+++ b/lib/rubocop/cop/capybara/specific_finders.rb
@@ -8,11 +8,10 @@ module RuboCop
       # @example
       #   # bad
       #   find('#some-id')
-      #   find('[visible][id=some-id]')
+      #   find('[id=some-id]')
       #
       #   # good
       #   find_by_id('some-id')
-      #   find_by_id('some-id', visible: true)
       #
       class SpecificFinders < ::RuboCop::Cop::Base
         extend AutoCorrector


### PR DESCRIPTION
Fixed bad case since it is not a violation if there is an attribute other than id.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [x] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).