### PR TITLE
Fix a false positive for `Capybara/SpecificFinders` when `find` with kind option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Drop Ruby 2.6 support. ([@ydah])
 - Add new `Capybara/RSpec/PredicateMatcher` cop. ([@ydah])
+- Fix a false positive for `Capybara/SpecificFinders` when `find` with kind option. ([@ydah])
 
 ## 2.18.0 (2023-04-21)
 

--- a/docs/modules/ROOT/pages/cops_capybara.adoc
+++ b/docs/modules/ROOT/pages/cops_capybara.adoc
@@ -212,6 +212,7 @@ Checks if there is a more specific finder offered by Capybara.
 # bad
 find('#some-id')
 find('[id=some-id]')
+find(:css, '#some-id')
 
 # good
 find_by_id('some-id')

--- a/spec/rubocop/cop/capybara/specific_finders_spec.rb
+++ b/spec/rubocop/cop/capybara/specific_finders_spec.rb
@@ -12,6 +12,29 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificFinders do
     RUBY
   end
 
+  it 'registers an offense when using `find` with kind' do
+    expect_offense(<<~RUBY)
+      find(:css, '#some-id')
+      ^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by_id` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id')
+    RUBY
+  end
+
+  it 'registers an offense when using `find` with kind ' \
+     'and option' do
+    expect_offense(<<~RUBY)
+      find(:css, '#some-id', class: 'some-cls')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by_id` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id', class: 'some-cls')
+    RUBY
+  end
+
   it 'registers an offense when using `find` with no parentheses' do
     expect_offense(<<~RUBY)
       find "#some-id"
@@ -149,6 +172,30 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificFinders do
 
     expect_correction(<<~RUBY)
       find_by_id('some-id')
+    RUBY
+  end
+
+  it 'registers an offense when using `find` ' \
+     'with argument is kind and attribute specified id' do
+    expect_offense(<<~RUBY)
+      find(:css, '[id=some-id]')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by_id` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id')
+    RUBY
+  end
+
+  it 'registers an offense when using `find` ' \
+     'with argument is kind and attribute specified id and option' do
+    expect_offense(<<~RUBY)
+      find(:css, '[id=some-id]', class: 'some-cls')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by_id` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id', class: 'some-cls')
     RUBY
   end
 


### PR DESCRIPTION
Support the following cases:

```ruby
find(:css, '#some-id')
```
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).