### PR TITLE
Fix an incorrect autocorrect for `Capybara/CurrentPathExpectation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix a false positive for `Capybara/SpecificFinders` when `find` with kind option. ([@ydah])
 - Add new `Capybara/RSpec/HaveSelector` cop. ([@ydah])
 - Add new `Capybara/ClickLinkOrButtonStyle` cop. ([@ydah])
+- Fix an incorrect autocorrect for `Capybara/CurrentPathExpectation`. ([@ydah])
 
 ## 2.18.0 (2023-04-21)
 

--- a/docs/modules/ROOT/pages/cops_capybara.adoc
+++ b/docs/modules/ROOT/pages/cops_capybara.adoc
@@ -86,15 +86,13 @@ This cop does not support autocorrection in some cases.
 ----
 # bad
 expect(current_path).to eq('/callback')
+expect(page.current_path).to eq('/callback')
 
 # good
-expect(page).to have_current_path('/callback')
+expect(page).to have_current_path('/callback', ignore_query: true)
 
-# bad (does not support autocorrection)
-expect(page.current_path).to match(variable)
-
-# good
-expect(page).to have_current_path('/callback')
+# bad (does not support autocorrection when `match` with a variable)
+expect(page).to match(variable)
 ----
 
 === References

--- a/spec/rubocop/cop/capybara/current_path_expectation_spec.rb
+++ b/spec/rubocop/cop/capybara/current_path_expectation_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RuboCop::Cop::Capybara::CurrentPathExpectation do
     RUBY
 
     expect_correction(<<~RUBY)
-      expect(page).to have_current_path "/callback"
+      expect(page).to have_current_path "/callback", ignore_query: true
     RUBY
   end
 
@@ -22,7 +22,7 @@ RSpec.describe RuboCop::Cop::Capybara::CurrentPathExpectation do
 
     expect_correction(<<~'RUBY')
       expect(page).to have_current_path "/callback" \
-                                  "/foo"
+                                  "/foo", ignore_query: true
     RUBY
   end
 
@@ -33,7 +33,7 @@ RSpec.describe RuboCop::Cop::Capybara::CurrentPathExpectation do
     RUBY
 
     expect_correction(<<~RUBY)
-      expect(page).to have_current_path `pwd`
+      expect(page).to have_current_path `pwd`, ignore_query: true
     RUBY
   end
 
@@ -41,6 +41,10 @@ RSpec.describe RuboCop::Cop::Capybara::CurrentPathExpectation do
     expect_offense(<<-RUBY)
       expect(page.current_path).to eq("/callback")
       ^^^^^^ Do not set an RSpec expectation on `current_path` in Capybara feature specs - instead, use the `have_current_path` matcher on `page`
+    RUBY
+
+    expect_correction(<<-RUBY)
+      expect(page).to have_current_path("/callback", ignore_query: true)
     RUBY
   end
 


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-capybara/issues/50

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).