### PR TITLE
Change to default `EnforcedStyle: link_or_button` for `Capybara/ClickLinkOrButtonStyle` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Edge (Unreleased)
 
+- Change to default `EnforcedStyle: link_or_button` for `Capybara/ClickLinkOrButtonStyle` cop. ([@ydah])
+
 ## 2.19.0 (2023-09-20)
 
 - Add new `Capybara/RSpec/PredicateMatcher` cop. ([@ydah])

--- a/config/default.yml
+++ b/config/default.yml
@@ -10,13 +10,14 @@ Capybara:
     - "**/features/step_definitions/**/*"
 
 Capybara/ClickLinkOrButtonStyle:
-  Description: Checks for click button or link style.
+  Description: Checks for methods of button or link clicks.
   Enabled: pending
   VersionAdded: '2.19'
-  EnforcedStyle: strict
+  VersionChanged: "<<next>>"
+  EnforcedStyle: link_or_button
   SupportedStyles:
-    - strict
     - link_or_button
+    - strict
   Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/ClickLinkOrButtonStyle
 
 Capybara/CurrentPathExpectation:

--- a/docs/modules/ROOT/pages/cops_capybara.adoc
+++ b/docs/modules/ROOT/pages/cops_capybara.adoc
@@ -9,27 +9,21 @@
 | Yes
 | No
 | 2.19
-| -
+| <<next>>
 |===
 
-Checks for click button or link style.
+Checks for methods of button or link clicks.
+
+By default, prefer to use `click_link_or_button` or `click_on`.
+These methods offer a weaker coupling between the test and HTML,
+allowing for a more faithful reflection of how the user behaves.
+
+You can set `EnforcedStyle: strict` to prefer the use of
+`click_link` and `click_button`, but this is a deprecated setting.
 
 === Examples
 
-==== EnforcedStyle: strict (default)
-
-[source,ruby]
-----
-# bad
-click_link_or_button('foo')
-click_on('foo')
-
-# good
-click_link('foo')
-click_button('foo')
-----
-
-==== EnforcedStyle: link_or_button
+==== EnforcedStyle: link_or_button (default)
 
 [source,ruby]
 ----
@@ -40,6 +34,19 @@ click_button('foo')
 # good
 click_link_or_button('foo')
 click_on('foo')
+----
+
+==== EnforcedStyle: strict
+
+[source,ruby]
+----
+# bad
+click_link_or_button('foo')
+click_on('foo')
+
+# good
+click_link('foo')
+click_button('foo')
 ----
 
 === Configurable attributes
@@ -48,8 +55,8 @@ click_on('foo')
 | Name | Default value | Configurable values
 
 | EnforcedStyle
-| `strict`
-| `strict`, `link_or_button`
+| `link_or_button`
+| `link_or_button`, `strict`
 |===
 
 === References

--- a/lib/rubocop/cop/capybara/click_link_or_button_style.rb
+++ b/lib/rubocop/cop/capybara/click_link_or_button_style.rb
@@ -3,18 +3,16 @@
 module RuboCop
   module Cop
     module Capybara
-      # Checks for click button or link style.
+      # Checks for methods of button or link clicks.
       #
-      # @example EnforcedStyle: strict (default)
-      #   # bad
-      #   click_link_or_button('foo')
-      #   click_on('foo')
+      # By default, prefer to use `click_link_or_button` or `click_on`.
+      # These methods offer a weaker coupling between the test and HTML,
+      # allowing for a more faithful reflection of how the user behaves.
       #
-      #   # good
-      #   click_link('foo')
-      #   click_button('foo')
+      # You can set `EnforcedStyle: strict` to prefer the use of
+      # `click_link` and `click_button`, but this is a deprecated setting.
       #
-      # @example EnforcedStyle: link_or_button
+      # @example EnforcedStyle: link_or_button (default)
       #   # bad
       #   click_link('foo')
       #   click_button('foo')
@@ -22,6 +20,15 @@ module RuboCop
       #   # good
       #   click_link_or_button('foo')
       #   click_on('foo')
+      #
+      # @example EnforcedStyle: strict
+      #   # bad
+      #   click_link_or_button('foo')
+      #   click_on('foo')
+      #
+      #   # good
+      #   click_link('foo')
+      #   click_button('foo')
       #
       class ClickLinkOrButtonStyle < ::RuboCop::Cop::Base
         include ConfigurableEnforcedStyle


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-capybara/pull/61#issuecomment-1727556658
Fix: https://github.com/rubocop/rubocop-capybara/pull/61#issuecomment-1740641746

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

- [x] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
