### PR TITLE
Fix a false negative for `RSpec/HaveSelector` when first argument is dstr node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Edge (Unreleased)
 
 - Change to default `EnforcedStyle: link_or_button` for `Capybara/ClickLinkOrButtonStyle` cop. ([@ydah])
+- Fix a false negative for `RSpec/HaveSelector` when first argument is dstr node. ([@ydah])
 
 ## 2.19.0 (2023-09-20)
 

--- a/lib/rubocop/cop/capybara/rspec/have_selector.rb
+++ b/lib/rubocop/cop/capybara/rspec/have_selector.rb
@@ -44,7 +44,7 @@ module RuboCop
           def on_send(node)
             argument = node.first_argument
             on_select_with_type(node, argument) if argument.sym_type?
-            on_select_without_type(node) if argument.str_type?
+            on_select_without_type(node) if %i[str dstr].include?(argument.type)
           end
 
           private

--- a/spec/rubocop/cop/capybara/rspec/have_selector_spec.rb
+++ b/spec/rubocop/cop/capybara/rspec/have_selector_spec.rb
@@ -51,6 +51,30 @@ RSpec.describe RuboCop::Cop::Capybara::RSpec::HaveSelector, :config do
     RUBY
   end
 
+  it 'registers an offense when using `have_selector` with `:css` ' \
+     'and "#{bar}"' do
+    expect_offense(<<~'RUBY')
+      expect(foo).to have_selector(:css, "#{bar}")
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `have_css` instead of `have_selector`.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      expect(foo).to have_css("#{bar}")
+    RUBY
+  end
+
+  it 'registers an offense when using `have_selector` with ' \
+     '"input[name=\'#{title}\']"' do
+    expect_offense(<<~'RUBY')
+      expect(foo).to have_selector("input[name='#{title}']")
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `have_css` instead of `have_selector`.
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      expect(foo).to have_css("input[name='#{title}']")
+    RUBY
+  end
+
   context 'when DefaultSelector is xpath' do
     let(:default_selector) { 'xpath' }
 


### PR DESCRIPTION
partially fixed: https://github.com/rubocop/rubocop-capybara/issues/78

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
