### PR TITLE
Correct a `InternalAffairs/NodeFirstOrLastArgument`

### DIFF
--- a/lib/rubocop/cop/capybara/specific_finders.rb
+++ b/lib/rubocop/cop/capybara/specific_finders.rb
@@ -76,7 +76,7 @@ module RuboCop
         end
 
         def deletion_range(node)
-          range_between(node.arguments[0].source_range.end_pos,
+          range_between(node.first_argument.source_range.end_pos,
                         node.arguments[1].source_range.end_pos)
         end
 


### PR DESCRIPTION
❯ bundle exec rubocop -A
Inspecting 40 files
.................C......................

Offenses:

lib/rubocop/cop/capybara/specific_finders.rb:79:30: C: [Corrected] InternalAffairs/NodeFirstOrLastArgument: Use #first_argument instead of #arguments[0].
          range_between(node.arguments[0].source_range.end_pos,
                             ^^^^^^^^^^^^

40 files inspected, 1 offense detected, 1 offense corrected

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
