### PR TITLE
Fix a false positive for `Capybara/SpecificMatcher` when `text:` or `exact_text:` with regexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add new `Capybara/RedundantWithinFind` cop. ([@ydah])
 - Fix an invalid attributes parse when name with multiple `[]` for `Capybara/SpecificFinders` and `Capybara/SpecificActions` and `Capybara/SpecificMatcher`. ([@ydah])
 - Change to default `EnforcedStyle: have_no` for `Capybara/NegationMatcher` cop. ([@ydah])
+- Fix a false positive for `Capybara/SpecificMatcher` when `text:` or `exact_text:` with regexp. ([@ydah])
 
 ## 2.19.0 (2023-09-20)
 

--- a/lib/rubocop/cop/capybara/specific_matcher.rb
+++ b/lib/rubocop/cop/capybara/specific_matcher.rb
@@ -42,6 +42,11 @@ module RuboCop
           (send nil? _ (str $_) ... )
         PATTERN
 
+        # @!method text_with_regexp?(node)
+        def_node_search :text_with_regexp?, <<-PATTERN
+          (pair (sym {:text :exact_text}) (regexp ...))
+        PATTERN
+
         def on_send(node)
           first_argument(node) do |arg|
             next unless (matcher = specific_matcher(arg))
@@ -61,6 +66,7 @@ module RuboCop
 
         def replaceable?(node, arg, matcher)
           replaceable_attributes?(arg) &&
+            !text_with_regexp?(node) &&
             CapybaraHelp.replaceable_option?(node, arg, matcher) &&
             CapybaraHelp.replaceable_pseudo_classes?(arg)
         end

--- a/spec/rubocop/cop/capybara/specific_matcher_spec.rb
+++ b/spec/rubocop/cop/capybara/specific_matcher_spec.rb
@@ -264,4 +264,20 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificMatcher do
       expect(page).to have_css(%{a[href="#{foo}"]}, text: "bar")
     RUBY
   end
+
+  it 'does not register an offense for abstract matcher when ' \
+     'exact_text: /some regex/' do
+    expect_no_offenses(<<-RUBY)
+      expect(page).to have_css('a', class: 'cls', exact_text: /some regex/)
+      expect(page).to have_css('button', exact_text: /some regex/, class: 'cls')
+    RUBY
+  end
+
+  it 'does not register an offense for abstract matcher when ' \
+     'text: /some regex/' do
+    expect_no_offenses(<<-RUBY)
+      expect(page).to have_css('select', class: 'cls', text: /some regex/)
+      expect(page).to have_css('table', text: /some regex/, class: 'cls')
+    RUBY
+  end
 end


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-capybara/issues/82

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
