### PR TITLE
Enable a few pending cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -149,6 +149,10 @@ RSpec/ContainExactly:
   Enabled: true
 RSpec/DuplicatedMetadata:
   Enabled: true
+RSpec/EmptyMetadata:
+  Enabled: true
+RSpec/Eq:
+  Enabled: true
 RSpec/ExcessiveDocstringSpacing:
   Enabled: true
 RSpec/IdenticalEqualityAssertion:
@@ -157,17 +161,25 @@ RSpec/IndexedLet:
   Enabled: true
 RSpec/MatchArray:
   Enabled: true
+RSpec/MetadataStyle:
+  Enabled: true
 RSpec/NoExpectationExample:
   Enabled: true
 RSpec/PendingWithoutReason:
   Enabled: true
+RSpec/ReceiveMessages:
+  Enabled: true
 RSpec/RedundantAround:
   Enabled: true
-RSpec/ReceiveMessages:
+RSpec/RedundantPredicateMatcher:
+  Enabled: true
+RSpec/RemoveConst:
   Enabled: true
 RSpec/SkipBlockInsideExample:
   Enabled: true
 RSpec/SortMetadata:
+  Enabled: true
+RSpec/SpecFilePathSuffix:
   Enabled: true
 RSpec/SubjectDeclaration:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'rake'
 gem 'rspec', '~> 3.11'
 gem 'rubocop-performance', '~> 1.7'
 gem 'rubocop-rake', '~> 0.6'
-gem 'rubocop-rspec', '~> 2.25.0'
+gem 'rubocop-rspec', '~> 2.26.0'
 gem 'simplecov', '>= 0.19'
 gem 'yard'
 


### PR DESCRIPTION
We released rubocop-rspec v2.26.0, so we update and enable a few pending cops.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
