### PR TITLE
Fix a false negative for `Capybara/NegationMatcher` when using `to_not `

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Edge (Unreleased)
 
+- Fix a false negative for `Capybara/NegationMatcher` when using `to_not`. ([@ydah])
+
 ## 2.20.0 (2024-01-03)
 
 - Change to default `EnforcedStyle: link_or_button` for `Capybara/ClickLinkOrButtonStyle` cop. ([@ydah])

--- a/lib/rubocop/cop/capybara/negation_matcher.rb
+++ b/lib/rubocop/cop/capybara/negation_matcher.rb
@@ -42,7 +42,7 @@ module RuboCop
 
         # @!method not_to?(node)
         def_node_matcher :not_to?, <<~PATTERN
-          (send ... :not_to
+          (send ... {:not_to :to_not}
             (send nil? %POSITIVE_MATCHERS ...))
         PATTERN
 

--- a/spec/rubocop/cop/capybara/negation_matcher_spec.rb
+++ b/spec/rubocop/cop/capybara/negation_matcher_spec.rb
@@ -33,6 +33,21 @@ RSpec.describe RuboCop::Cop::Capybara::NegationMatcher do
     end
 
     it 'registers an offense when using ' \
+       '`expect(...).to_not have_matcher`' do
+      expect_offense(<<~RUBY)
+        expect(page).to_not have_selector
+                     ^^^^^^^^^^^^^^^^^^^^ Use `expect(...).to have_no_selector`.
+        expect(page).to_not have_css('a')
+                     ^^^^^^^^^^^^^^^ Use `expect(...).to have_no_css`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(page).to have_no_selector
+        expect(page).to have_no_css('a')
+      RUBY
+    end
+
+    it 'registers an offense when using ' \
        '`expect(...).not_to have_text` with heredoc' do
       expect_offense(<<~RUBY)
         expect(page).not_to have_text(exact_text: <<~TEXT)


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-capybara/issues/90

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
