### PR TITLE
Enable cop for pending rubocop-performance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -133,6 +133,43 @@ Style/RedundantStringEscape:
 Style/ReturnNilInPredicateMethodDefinition:
   Enabled: true
 
+# Enable pending rubocop-performance cops.
+
+Performance/AncestorsInclude:
+  Enabled: true
+Performance/BlockGivenWithExplicitBlock:
+  Enabled: true
+Performance/CollectionLiteralInLoop:
+  Enabled: true
+Performance/ConstantRegexp:
+  Enabled: true
+Performance/MapCompact:
+  Enabled: true
+Performance/MapMethodChain:
+  Enabled: true
+Performance/MethodObjectAsBlock:
+  Enabled: true
+Performance/RedundantEqualityComparisonBlock:
+  Enabled: true
+Performance/RedundantSortBlock:
+  Enabled: true
+Performance/RedundantSplitRegexpArgument:
+  Enabled: true
+Performance/RedundantStringChars:
+  Enabled: true
+Performance/ReverseFirst:
+  Enabled: true
+Performance/SortReverse:
+  Enabled: true
+Performance/Squeeze:
+  Enabled: true
+Performance/StringIdentifierArgument:
+  Enabled: true
+Performance/StringInclude:
+  Enabled: true
+Performance/Sum:
+  Enabled: true
+
 # Enable pending rubocop-rspec cops.
 
 RSpec/BeEmpty:

--- a/lib/rubocop/cop/capybara/specific_finders.rb
+++ b/lib/rubocop/cop/capybara/specific_finders.rb
@@ -106,11 +106,11 @@ module RuboCop
         end
 
         def to_options(attrs)
-          attrs.each.map do |key, value|
+          attrs.each.filter_map do |key, value|
             next if key == 'id'
 
             "#{key}: #{value}"
-          end.compact.join(', ')
+          end.join(', ')
         end
 
         def offense_range(node)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ spec_helper_glob =
 Dir
   .glob(File.expand_path(spec_helper_glob, __dir__))
   .sort
-  .each(&method(:require))
+  .each { |file| require file }
 
 RSpec.configure do |config|
   # Set metadata so smoke tests are run on all cop specs


### PR DESCRIPTION
This PR enable cop for pending rubocop-performance and correct some offense.

```
❯ bundle exec rubocop
Inspecting 44 files
...................C.....................C..

Offenses:

lib/rubocop/cop/capybara/specific_finders.rb:109:22: C: [Correctable] Performance/MapCompact: Use filter_map instead.
          attrs.each.map do |key, value| ...
                     ^^^^^^^^^^^^^^^^^^^
spec/spec_helper.rb:17:9: C: Performance/MethodObjectAsBlock: Use block explicitly instead of block-passing a method object.
  .each(&method(:require))
        ^^^^^^^^^^^^^^^^^

44 files inspected, 2 offenses detected, 1 offense autocorrectable
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
