### PR TITLE
Fix a false negative for `Capybara/SpecificFinders` when using `find(:id, 'some-id')`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Edge (Unreleased)
 
 - Fix a false negative for `Capybara/NegationMatcher` when using `to_not`. ([@ydah])
+- Fix a false negative for `Capybara/SpecificFinders` when using `find(:id, 'some-id')`. ([@ydah])
 
 ## 2.20.0 (2024-01-03)
 

--- a/docs/modules/ROOT/pages/cops_capybara.adoc
+++ b/docs/modules/ROOT/pages/cops_capybara.adoc
@@ -323,6 +323,7 @@ Checks if there is a more specific finder offered by Capybara.
 find('#some-id')
 find('[id=some-id]')
 find(:css, '#some-id')
+find(:id, 'some-id')
 
 # good
 find_by_id('some-id')

--- a/lib/rubocop/cop/capybara/specific_finders.rb
+++ b/lib/rubocop/cop/capybara/specific_finders.rb
@@ -10,6 +10,7 @@ module RuboCop
       #   find('#some-id')
       #   find('[id=some-id]')
       #   find(:css, '#some-id')
+      #   find(:id, 'some-id')
       #
       #   # good
       #   find_by_id('some-id')
@@ -23,7 +24,7 @@ module RuboCop
 
         # @!method find_argument(node)
         def_node_matcher :find_argument, <<~PATTERN
-          (send _ :find $(sym :css)? (str $_) ...)
+          (send _ :find $(sym {:css :id})? (str $_) ...)
         PATTERN
 
         # @!method class_options(node)
@@ -38,6 +39,7 @@ module RuboCop
 
             on_attr(node, sym, arg) if attribute?(arg)
             on_id(node, sym, arg) if CssSelector.id?(arg)
+            on_sym_id(node, sym, arg) if sym.first&.value == :id
           end
         end
 
@@ -57,6 +59,10 @@ module RuboCop
           id = CssSelector.id(arg)
           register_offense(node, sym, "'#{id}'",
                            CssSelector.classes(arg.sub("##{id}", '')))
+        end
+
+        def on_sym_id(node, sym, id)
+          register_offense(node, sym, "'#{id}'")
         end
 
         def attribute?(arg)

--- a/spec/rubocop/cop/capybara/specific_finders_spec.rb
+++ b/spec/rubocop/cop/capybara/specific_finders_spec.rb
@@ -35,6 +35,29 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificFinders do
     RUBY
   end
 
+  it 'registers an offense when using `find` with `:id`' do
+    expect_offense(<<~RUBY)
+      find(:id, 'some-id')
+      ^^^^^^^^^^^^^^^^^^^^ Prefer `find_by_id` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id')
+    RUBY
+  end
+
+  it 'registers an offense when using `find` with `:id` ' \
+     'and option' do
+    expect_offense(<<~RUBY)
+      find(:id, 'some-id', class: 'some-cls')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by_id` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id', class: 'some-cls')
+    RUBY
+  end
+
   it 'registers an offense when using `find` with no parentheses' do
     expect_offense(<<~RUBY)
       find "#some-id"


### PR DESCRIPTION
Support cases that `find` the following `id`:

```
# refs https://rubydoc.info/github/teamcapybara/capybara/master/Capybara/Selector
page.html # => '<input id="field">'

page.find :id, 'field'
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
