### PR TITLE
Fix an error for `Capybara/RSpec/HaveSelector` when passing no arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `Capybara/AmbiguousClick` cop and make soft-deprecated `Capybara/ClickLinkOrButtonStyle` cop. If you want to use `EnforcedStyle: strict`, use `Capybara/AmbiguousClick` cop instead. ([@ydah])
 - Add new `Capybara/FindAllFirst` cop. ([@ydah])
+- Fix an error for `Capybara/RSpec/HaveSelector` when passing no arguments. ([@earlopain])
 
 ## 2.21.0 (2024-06-08)
 
@@ -78,6 +79,7 @@
 [@aried3r]: https://github.com/aried3r
 [@bquorning]: https://github.com/bquorning
 [@darhazer]: https://github.com/Darhazer
+[@earlopain]: https://github.com/earlopain
 [@onumis]: https://github.com/onumis
 [@oskarsezerins]: https://github.com/OskarsEzerins
 [@pirj]: https://github.com/pirj

--- a/lib/rubocop/cop/capybara/rspec/have_selector.rb
+++ b/lib/rubocop/cop/capybara/rspec/have_selector.rb
@@ -42,7 +42,8 @@ module RuboCop
           SELECTORS = %i[css xpath].freeze
 
           def on_send(node)
-            argument = node.first_argument
+            return unless (argument = node.first_argument)
+
             on_select_with_type(node, argument) if argument.sym_type?
             on_select_without_type(node) if %i[str dstr].include?(argument.type)
           end

--- a/spec/rubocop/cop/capybara/rspec/have_selector_spec.rb
+++ b/spec/rubocop/cop/capybara/rspec/have_selector_spec.rb
@@ -75,6 +75,12 @@ RSpec.describe RuboCop::Cop::Capybara::RSpec::HaveSelector, :config do
     RUBY
   end
 
+  it 'registers no offense when no arguments are passed' do
+    expect_no_offenses(<<~RUBY)
+      expect(foo).to have_selector
+    RUBY
+  end
+
   context 'when DefaultSelector is xpath' do
     let(:default_selector) { 'xpath' }
 


### PR DESCRIPTION
`ruby-lsp` constanty runs RuboCop over code while typing, so this error will just happen.

Do note that there are currently 2 RuboCop offenses introduced through new `rubocop` versions:

```
Offenses:

lib/rubocop/cop/capybara/rspec/have_selector.rb:82:30: C: InternalAffairs/UndefinedConfig: DefaultSelector is not defined in the configuration for Capybara/RSpec/HaveSelector in config/default.yml.
            cop_config.fetch('DefaultSelector', 'css')
                             ^^^^^^^^^^^^^^^^^
tasks/cut_release.rake:41:21: W: [Correctable] Lint/ImplicitStringConcatenation: Combine '\0' and "## #{version} (#{Time.now.strftime('%F')})\n\n" into a single string literal, rather than using implicit string concatenation. Or, if they were intended to be separate method arguments, separate them with a comma.
                    '\0' "## #{version} (#{Time.now.strftime('%F')})\n\n")
```

The second one seems pretty straightforward, the other I'm not sure about. It seems fine to me but when the cop is ran the fetched config is just empty. I'm not sure why but a commit similar to this would fix it: https://github.com/rubocop/rubocop-rails/commit/5180fa2c25cef467eececd9c80739f7cad6adbbf (i.e. adding `rubocop-capybara` to its own `.rubocop.yml` file.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).