### PR TITLE
Fix the flaky test for spec/rubocop/capybara/description_extractor_spec.rb

### DIFF
--- a/spec/rubocop/capybara/description_extractor_spec.rb
+++ b/spec/rubocop/capybara/description_extractor_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe RuboCop::Capybara::DescriptionExtractor do
   end
 
   before do
+    YARD::Registry.clear
     stub_cop_const('Foo')
     stub_cop_const('Undocumented')
   end


### PR DESCRIPTION

```
RuboCop::Capybara::DescriptionExtractor
  builds a hash of descriptions (FAILED - 1)

Failures:

  1) RuboCop::Capybara::DescriptionExtractor builds a hash of descriptions
     Failure/Error:
       expect(described_class.new(yardocs).to_h).to eql(
         'Capybara/Foo'          => { 'Description' => 'Checks foo' },
         'Capybara/Undocumented' => { 'Description' => ''           }
       )

       expected: {"Capybara/Foo"=>{"Description"=>"Checks foo"}, "Capybara/Undocumented"=>{"Description"=>""}}
            got: {"Capybara/AmbiguousClick"=>{"Description"=>"Specify the exact target to click on."}, "Capybara/Click..."Capybara/VisibilityMatcher"=>{"Description"=>"Checks for boolean visibility in Capybara finders."}}

       (compared using eql?)

       Diff:

       @@ -1,3 +1,16 @@
       +"Capybara/AmbiguousClick" => {"Description"=>"Specify the exact target to click on."},
       +"Capybara/ClickLinkOrButtonStyle" => {"Description"=>"Checks for methods of button or link clicks."},
       +"Capybara/CurrentPathExpectation" => {"Description"=>"Checks that no expectations are set on Capybara's `current_path`."},
       +"Capybara/FindAllFirst" => {"Description"=>"Enforces use of `first` instead of `all` with `first` or `[0]`."},
        "Capybara/Foo" => {"Description"=>"Checks foo"},
       +"Capybara/MatchStyle" => {"Description"=>"Checks for usage of deprecated style methods."},
       +"Capybara/NegationMatcher" => {"Description"=>"Enforces use of `have_no_*` or `not_to` for negated expectations."},
       +"Capybara/RSpec/HaveSelector" => {"Description"=>"Use `have_css` or `have_xpath` instead of `have_selector`."},
       +"Capybara/RSpec/PredicateMatcher" => {"Description"=>"Prefer using predicate matcher over using predicate method directly."},
       +"Capybara/RedundantWithinFind" => {"Description"=>"Checks for redundant `within find(...)` calls."},
       +"Capybara/SpecificActions" => {"Description"=>"Checks for there is a more specific actions offered by Capybara."},
       +"Capybara/SpecificFinders" => {"Description"=>"Checks if there is a more specific finder offered by Capybara."},
       +"Capybara/SpecificMatcher" => {"Description"=>"Checks for there is a more specific matcher offered by Capybara."},
        "Capybara/Undocumented" => {"Description"=>""},
       +"Capybara/VisibilityMatcher" => {"Description"=>"Checks for boolean visibility in Capybara finders."},

     # ./spec/rubocop/capybara/description_extractor_spec.rb:66:in `block (2 levels) in <top (required)>'

Finished in 0.33675 seconds (files took 0.6663 seconds to load)
381 examples, 1 failure

Failed examples:

rspec ./spec/rubocop/capybara/description_extractor_spec.rb:65 # RuboCop::Capybara::DescriptionExtractor builds a hash of descriptions

Randomized with seed 30192
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
