### PR TITLE
Fix a rubocop offense

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 require:
+  - rubocop-capybara
   - rubocop-performance
   - rubocop-rake
   - rubocop-rspec


### PR DESCRIPTION
This PR fixes a rubocop offense for `InternalAffairs/UndefinedConfig`

```
❯ bundle exec rubocop
Inspecting 50 files
...................C..............................

Offenses:

lib/rubocop/cop/capybara/rspec/have_selector.rb:81:30: C: InternalAffairs/UndefinedConfig: DefaultSelector is not defined in the configuration for Capybara/RSpec/HaveSelector in config/default.yml.
            cop_config.fetch('DefaultSelector', 'css')
                             ^^^^^^^^^^^^^^^^^

50 files inspected, 1 offense detected
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
