### PR TITLE
Use node groups in node patterns to replace unions of types

### DIFF
--- a/lib/rubocop/cop/capybara/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/capybara/rspec/predicate_matcher.rb
@@ -44,7 +44,7 @@ module RuboCop
 
           # @!method be_bool?(node)
           def_node_matcher :be_bool?, <<~PATTERN
-            (send nil? {:be :eq :eql :equal} {true false})
+            (send nil? {:be :eq :eql :equal} boolean)
           PATTERN
 
           # @!method be_boolthy?(node)


### PR DESCRIPTION
`rubocop-ast` defines some node groups (https://github.com/rubocop/rubocop-ast/blob/85bfe84/lib/rubocop/ast/node.rb#L89-L116) that can be used in place of a union of node types.