### PR TITLE
Only run publish workflow on upstream repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ jobs:
   publish:
     name: Publish to RubyGems
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'rubocop'
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
When syncing forks, they also try to publish (which doesn't make a lot of sense and doesn't work)

Ref: https://github.com/rubocop/rubocop-rspec/pull/2050