### PR TITLE
Fix incorrect plugin version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Edge (Unreleased)
 
+- Fix incorrect plugin version. ([@koic])
+
 ## 2.22.0 (2025-03-10)
 
 - Add `Capybara/AmbiguousClick` cop and make soft-deprecated `Capybara/ClickLinkOrButtonStyle` cop. If you want to use `EnforcedStyle: strict`, use `Capybara/AmbiguousClick` cop instead. ([@ydah])
@@ -84,6 +86,7 @@
 [@bquorning]: https://github.com/bquorning
 [@darhazer]: https://github.com/Darhazer
 [@earlopain]: https://github.com/earlopain
+[@koic]: https://github.com/koic
 [@onumis]: https://github.com/onumis
 [@oskarsezerins]: https://github.com/OskarsEzerins
 [@pirj]: https://github.com/pirj

--- a/lib/rubocop-capybara.rb
+++ b/lib/rubocop-capybara.rb
@@ -6,6 +6,7 @@ require 'yaml'
 require 'rubocop'
 
 require_relative 'rubocop/capybara/plugin'
+require_relative 'rubocop/capybara/version'
 
 require_relative 'rubocop/cop/capybara/mixin/capybara_help'
 require_relative 'rubocop/cop/capybara/mixin/css_attributes_parser'


### PR DESCRIPTION
`require_relative 'rubocop/capybara/version'` was missing, causing the constant lookup for `Version::STRING` in `lib/rubocop/capybara/plugin.rb` to resolve to `RuboCop::Version::STRING` instead of `RuboCop::Capybara::Version::STRING`.

This PR fixes an issue where `rubocop -V` incorrectly displayed the RuboCop version instead of the rubocop-capybara version:

```console
$ bundle exec rubocop -V
1.73.2 (using Parser 3.3.7.1, rubocop-ast 1.38.1, analyzing as Ruby 2.7, running on ruby 3.4.2) [x86_64-darwin23]
  - rubocop-performance 1.24.0
  - rubocop-rake 0.7.1
  - rubocop-capybara 1.73.2
  - rubocop-factory_bot 1.73.2
  - rubocop-rspec_rails 2.31.0
  - rubocop-rspec 3.5.0
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
