### PR TITLE
Fix format of link to Capybara docs

### DIFF
--- a/docs/modules/ROOT/pages/cops_capybara.adoc
+++ b/docs/modules/ROOT/pages/cops_capybara.adoc
@@ -554,8 +554,7 @@ values, however using booleans can have unwanted effects. `visible:
 false` does not find just invisible elements, but both visible and
 invisible elements. For expressiveness and clarity, use one of the
 symbol values, `:all`, `:hidden` or `:visible`.
-Read more in
-https://www.rubydoc.info/gems/capybara/Capybara%2FNode%2FFinders:all[the documentation].
+Read more at: https://www.rubydoc.info/gems/capybara/Capybara%2FNode%2FFinders:all
 
 [#examples-capybaravisibilitymatcher]
 === Examples

--- a/lib/rubocop/cop/capybara/visibility_matcher.rb
+++ b/lib/rubocop/cop/capybara/visibility_matcher.rb
@@ -11,8 +11,7 @@ module RuboCop
       # false` does not find just invisible elements, but both visible and
       # invisible elements. For expressiveness and clarity, use one of the
       # symbol values, `:all`, `:hidden` or `:visible`.
-      # Read more in
-      # https://www.rubydoc.info/gems/capybara/Capybara%2FNode%2FFinders:all[the documentation].
+      # Read more at: https://www.rubydoc.info/gems/capybara/Capybara%2FNode%2FFinders:all
       #
       # @example
       #   # bad


### PR DESCRIPTION
Replace the adoc format link with a plain link that also works in rdoc. 
Reason: Rubocop itself links to 
https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/VisibilityMatcher 
which seems not to render the adoc format: 

![image](https://github.com/user-attachments/assets/e27c3a11-a29e-4720-acbf-01d4ac36b516)

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [x] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
