### PR TITLE
Add support for using `find` with `:link` and `:field` in `Capybara/SpecificFinders` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix a false positive for `Capybara/SpecificActions` when `click` uses arguments or a block. ([@ydah])
 - Fix an incorrect autocorrect for `Capybara/SpecificFinders` when a selector class is used with nested `class:` options. ([@ydah])
 - Fix CSS attribute parsing when attribute values contain quotes. ([@ydah])
+- Add support for using `find` with `:link` and `:field` in `Capybara/SpecificFinders` cop. ([@ydah])
 
 ## 3.0.0 (2026-06-22)
 

--- a/docs/modules/ROOT/pages/cops_capybara.adoc
+++ b/docs/modules/ROOT/pages/cops_capybara.adoc
@@ -228,9 +228,13 @@ find('#some-id')
 find('[id=some-id]')
 find(:css, '#some-id')
 find(:id, 'some-id')
+find(:link, 'Home')
+find(:field, 'Name')
 
 # good
 find_by_id('some-id')
+find_link('Home')
+find_field('Name')
 ----
 
 [#references-capybaraspecificfinders]

--- a/lib/rubocop/cop/capybara/specific_finders.rb
+++ b/lib/rubocop/cop/capybara/specific_finders.rb
@@ -11,20 +11,24 @@ module RuboCop
       #   find('[id=some-id]')
       #   find(:css, '#some-id')
       #   find(:id, 'some-id')
+      #   find(:link, 'Home')
+      #   find(:field, 'Name')
       #
       #   # good
       #   find_by_id('some-id')
+      #   find_link('Home')
+      #   find_field('Name')
       #
-      class SpecificFinders < ::RuboCop::Cop::Base
+      class SpecificFinders < ::RuboCop::Cop::Base # rubocop:disable Metrics/ClassLength
         extend AutoCorrector
         include RangeHelp
 
-        MSG = 'Prefer `find_by_id` over `find`.'
+        MSG = 'Prefer `%<replacement>s` over `find`.'
         RESTRICT_ON_SEND = %i[find].freeze
 
         # @!method find_argument(node)
         def_node_matcher :find_argument, <<~PATTERN
-          (send _ :find $(sym {:css :id})? (str $_) ...)
+          (send _ :find $(sym {:css :id :link :field})? (str $_) ...)
         PATTERN
 
         # @!method class_option(node)
@@ -32,7 +36,7 @@ module RuboCop
           (send _ :find ... (hash <(pair (sym :class) $_) ...>))
         PATTERN
 
-        def on_send(node)
+        def on_send(node) # rubocop:disable Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
           find_argument(node) do |sym, arg|
             next if CssSelector.pseudo_classes(arg).any?
             next if CssSelector.multiple_selectors?(arg)
@@ -40,10 +44,38 @@ module RuboCop
             on_attr(node, sym, arg) if attribute?(arg)
             on_id(node, sym, arg) if CssSelector.id?(arg)
             on_sym_id(node, sym, arg) if sym.first&.value == :id
+            on_sym_selector(node, sym) if sym.first && selector?(sym)
           end
         end
 
         private
+
+        def selector?(sym)
+          %i[link field].include?(sym.first.value)
+        end
+
+        def on_sym_selector(node, sym)
+          replacement = "find_#{sym.first.value}"
+          register_selector_offense(node, replacement)
+        end
+
+        def register_selector_offense(node, replacement)
+          message = format(MSG, replacement: replacement)
+          add_offense(offense_range(node), message: message) do |corrector|
+            corrector.replace(node.loc.selector, replacement)
+            remove_selector_argument(corrector, node)
+          end
+        end
+
+        def remove_selector_argument(corrector, node)
+          if node.arguments.size == 1
+            corrector.remove(node.first_argument)
+          else
+            range = range_between(node.first_argument.source_range.begin_pos,
+                                  node.arguments[1].source_range.begin_pos)
+            corrector.remove(range)
+          end
+        end
 
         def on_attr(node, sym, arg)
           attrs = CssSelector.attributes(arg)
@@ -71,14 +103,17 @@ module RuboCop
         end
 
         def register_offense(node, sym, replacement, classes = [])
-          add_offense(offense_range(node)) do |corrector|
+          message = format(MSG, replacement: 'find_by_id')
+          add_offense(offense_range(node), message: message) do |corrector|
             corrector.replace(node.loc.selector, 'find_by_id')
             corrector.replace(node.first_argument, replacement)
-            unless classes.compact.empty?
-              autocorrect_classes(corrector, node, classes)
-            end
+            autocorrect_id_classes(corrector, node, classes)
             corrector.remove(deletion_range(node)) unless sym.empty?
           end
+        end
+
+        def autocorrect_id_classes(corrector, node, classes)
+          autocorrect_classes(corrector, node, classes) if classes.compact.any?
         end
 
         def deletion_range(node)

--- a/spec/rubocop/cop/capybara/specific_finders_spec.rb
+++ b/spec/rubocop/cop/capybara/specific_finders_spec.rb
@@ -260,6 +260,18 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificFinders do
     RUBY
   end
 
+  it 'registers an offense when using `find` ' \
+     'with argument is attribute specified id and style attribute' do
+    expect_offense(<<~RUBY)
+      find('[id=some-id][style=display:none]')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by_id` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id', style: 'display:none')
+    RUBY
+  end
+
   it 'does not register an offense when using `find ' \
      'with argument is attribute not specified id' do
     expect_no_offenses(<<~RUBY)
@@ -329,6 +341,64 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificFinders do
       find('#foo:enabled')
       find('#foo:not(:disabled)')
       find('#foo:is(:enabled,:checked)')
+    RUBY
+  end
+
+  it 'registers an offense when using `find` with `:link`' do
+    expect_offense(<<~RUBY)
+      find(:link, 'Home')
+      ^^^^^^^^^^^^^^^^^^^ Prefer `find_link` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_link('Home')
+    RUBY
+  end
+
+  it 'registers an offense when using `find` with `:field`' do
+    expect_offense(<<~RUBY)
+      find(:field, 'Name')
+      ^^^^^^^^^^^^^^^^^^^^ Prefer `find_field` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_field('Name')
+    RUBY
+  end
+
+  it 'registers an offense when using `find` with `:link` ' \
+     'and option' do
+    expect_offense(<<~RUBY)
+      find(:link, 'Home', class: 'navbar-link')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_link` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_link('Home', class: 'navbar-link')
+    RUBY
+  end
+
+  it 'registers an offense when using `find` with `:field` ' \
+     'and option' do
+    expect_offense(<<~RUBY)
+      find(:field, 'Email', visible: false)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_field` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_field('Email', visible: false)
+    RUBY
+  end
+
+  it 'does not register an offense when using `find_link`' do
+    expect_no_offenses(<<~RUBY)
+      find_link('Home')
+    RUBY
+  end
+
+  it 'does not register an offense when using `find_field`' do
+    expect_no_offenses(<<~RUBY)
+      find_field('Name')
     RUBY
   end
 end


### PR DESCRIPTION
Fixes: https://github.com/rubocop/rubocop-capybara/issues/110

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
