### PR TITLE
CI: Test RSpec 4 prerelease on rspec main branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,15 +83,15 @@ jobs:
     name: RSpec 4
     steps:
       - uses: actions/checkout@v6
-      - name: Use latest RSpec 4 from `4-0-dev` branch
+      - name: Use latest RSpec 4 from `main` branch
         run: |
           sed -e '/rspec/d' -i Gemfile
           cat << EOF > Gemfile.local
-            gem 'rspec', github: 'rspec/rspec', branch: '4-0-dev'
-            gem 'rspec-core', github: 'rspec/rspec', branch: '4-0-dev'
-            gem 'rspec-expectations', github: 'rspec/rspec', branch: '4-0-dev'
-            gem 'rspec-mocks', github: 'rspec/rspec', branch: '4-0-dev'
-            gem 'rspec-support', github: 'rspec/rspec', branch: '4-0-dev'
+            gem 'rspec', github: 'rspec/rspec', branch: 'main'
+            gem 'rspec-core', github: 'rspec/rspec', branch: 'main'
+            gem 'rspec-expectations', github: 'rspec/rspec', branch: 'main'
+            gem 'rspec-mocks', github: 'rspec/rspec', branch: 'main'
+            gem 'rspec-support', github: 'rspec/rspec', branch: 'main'
           EOF
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
[The 4-0-dev branch](https://github.com/rspec/rspec/tree/4-0-dev) hasn't been used in a couple of years; the RSpec 4.0-pre development seems to happen on [the main branch](https://github.com/rspec/rspec/tree/main).

Related: ea1b2a65e85c3eebd4608554e19b3cc976db3f05
