### PR TITLE
Fix an incorrect autocorrect for `Capybara/FindAllFirst` when `find` or `all` with `match: :first` uses a receiver and mark autocorrection as unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - Rename `Capybara/VisibilityMatcher` to `Capybara/RSpec/VisibilityMatcher`
 - Split `Capybara/MatchStyle` into `Capybara/AssertStyle` and `Capybara/RSpec/MatchStyle`. ([@ydah])
 - Fix a false positive for `Capybara/FindAllFirst` when using logical operators with `all('...')[0]`. ([@ydah])
+- Fix an incorrect autocorrect for `Capybara/FindAllFirst` when `find` or `all` with `match: :first` uses a receiver and mark autocorrection as unsafe. ([@ydah])
 - Fix an error for `Capybara/RSpec/HaveSelector` when passing only a selector type. ([@ydah])
 
 ## 2.22.1 (2025-03-12)

--- a/config/default.yml
+++ b/config/default.yml
@@ -35,7 +35,9 @@ Capybara/ClickLinkOrButtonStyle:
 Capybara/FindAllFirst:
   Description: Enforces use of `first` instead of `all` with `first` or `[0]`.
   Enabled: pending
+  SafeAutoCorrect: false
   VersionAdded: '2.22'
+  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/FindAllFirst
 
 Capybara/RedundantWithinFind:

--- a/docs/modules/ROOT/pages/cops_capybara.adoc
+++ b/docs/modules/ROOT/pages/cops_capybara.adoc
@@ -160,12 +160,21 @@ click_button('foo')
 
 | Pending
 | Yes
-| Always
+| Always (Unsafe)
 | 2.22
-| -
+| <<next>>
 |===
 
 Enforces use of `first` instead of `all` with `first` or `[0]`.
+
+[#safety-capybarafindallfirst]
+=== Safety
+
+This cop's autocorrection is unsafe because `all` returns a
+`Capybara::Result` (an enumerable collection), while `first`
+returns a single `Capybara::Node::Element`. Replacing `all`
+with `first` may break code that depends on the return value
+being a collection (e.g. calling `.each` on the result).
 
 [#examples-capybarafindallfirst]
 === Examples

--- a/lib/rubocop/cop/capybara/find_all_first.rb
+++ b/lib/rubocop/cop/capybara/find_all_first.rb
@@ -5,6 +5,13 @@ module RuboCop
     module Capybara
       # Enforces use of `first` instead of `all` with `first` or `[0]`.
       #
+      # @safety
+      #   This cop's autocorrection is unsafe because `all` returns a
+      #   `Capybara::Result` (an enumerable collection), while `first`
+      #   returns a single `Capybara::Node::Element`. Replacing `all`
+      #   with `first` may break code that depends on the return value
+      #   being a collection (e.g. calling `.each` on the result).
+      #
       # @example
       #
       #   # bad
@@ -61,9 +68,11 @@ module RuboCop
           include_match_first?(node) do |hash|
             selector = ([node.first_argument.source] + replaced_hash(hash))
               .join(', ')
-            add_offense(node,
+            range = range_between(node.loc.selector.begin_pos,
+                                  node.source_range.end_pos)
+            add_offense(range,
                         message: format(MSG, selector: selector)) do |corrector|
-              corrector.replace(node, "first(#{selector})")
+              corrector.replace(range, "first(#{selector})")
             end
           end
         end

--- a/spec/rubocop/cop/capybara/find_all_first_spec.rb
+++ b/spec/rubocop/cop/capybara/find_all_first_spec.rb
@@ -37,6 +37,20 @@ RSpec.describe RuboCop::Cop::Capybara::FindAllFirst, :config do
     RUBY
   end
 
+  it 'registers an offense for `find(..., match: :first)` with receiver' do
+    expect_offense(<<~RUBY)
+      page.find('a', match: :first)
+           ^^^^^^^^^^^^^^^^^^^^^^^^ Use `first('a')`.
+      page.find('a', text: 'b', match: :first)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `first('a', text: 'b')`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      page.first('a')
+      page.first('a', text: 'b')
+    RUBY
+  end
+
   it 'registers an offense when using `all` with `match: :first`' do
     expect_offense(<<~RUBY)
       all('a', match: :first)
@@ -48,6 +62,20 @@ RSpec.describe RuboCop::Cop::Capybara::FindAllFirst, :config do
     expect_correction(<<~RUBY)
       first('a')
       first('a', text: 'b')
+    RUBY
+  end
+
+  it 'registers an offense for `all(..., match: :first)` with receiver' do
+    expect_offense(<<~RUBY)
+      page.all('a', match: :first)
+           ^^^^^^^^^^^^^^^^^^^^^^^ Use `first('a')`.
+      page.all('a', text: 'b', match: :first)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `first('a', text: 'b')`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      page.first('a')
+      page.first('a', text: 'b')
     RUBY
   end
 


### PR DESCRIPTION
Fixes: https://github.com/rubocop/rubocop-capybara/issues/167

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
