### PR TITLE
Enable pending Capybara cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Remove the deprecated `Capybara/ClickLinkOrButtonStyle` cop. ([@ydah])
 - Remove obsolete cop name migration config for the 2.x to 3.0 transition. ([@ydah])
+- Enable pending cops by default for the 3.0 release. ([@ydah])
 
 ## 2.23.0 (2026-04-30)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -17,34 +17,38 @@ Capybara/AmbiguousClick:
 
 Capybara/AssertStyle:
   Description: Checks for usage of deprecated assert style method.
-  Enabled: pending
+  Enabled: true
   VersionAdded: '2.23'
+  VersionChanged: '3.0'
   Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/AssertStyle
 
 Capybara/FindAllFirst:
   Description: Enforces use of `first` instead of `all` with `first` or `[0]`.
-  Enabled: pending
+  Enabled: true
   SafeAutoCorrect: false
   VersionAdded: '2.22'
-  VersionChanged: '2.23'
+  VersionChanged: '3.0'
   Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/FindAllFirst
 
 Capybara/RedundantWithinFind:
   Description: Checks for redundant `within find(...)` calls.
-  Enabled: pending
+  Enabled: true
   VersionAdded: '2.20'
+  VersionChanged: '3.0'
   Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/RedundantWithinFind
 
 Capybara/SpecificActions:
   Description: Checks for there is a more specific actions offered by Capybara.
-  Enabled: pending
+  Enabled: true
   VersionAdded: '2.14'
+  VersionChanged: '3.0'
   Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/SpecificActions
 
 Capybara/SpecificFinders:
   Description: Checks if there is a more specific finder offered by Capybara.
-  Enabled: pending
+  Enabled: true
   VersionAdded: '2.13'
+  VersionChanged: '3.0'
   Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/SpecificFinders
 
 Capybara/RSpec:
@@ -53,35 +57,38 @@ Capybara/RSpec:
 
 Capybara/RSpec/CurrentPathExpectation:
   Description: Checks that no expectations are set on Capybara's `current_path`.
-  Enabled: pending
+  Enabled: true
   VersionAdded: '1.18'
-  VersionChanged: '2.23'
+  VersionChanged: '3.0'
   Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/RSpec/CurrentPathExpectation
 
 Capybara/RSpec/HaveContent:
   Description: Checks for usage of `have_content` and `have_no_content`.
-  Enabled: pending
+  Enabled: true
   VersionAdded: '2.23'
+  VersionChanged: '3.0'
   Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/RSpec/HaveContent
 
 Capybara/RSpec/HaveSelector:
   Description: Use `have_css` or `have_xpath` instead of `have_selector`.
-  Enabled: pending
+  Enabled: true
   DefaultSelector: css
   VersionAdded: '2.19'
+  VersionChanged: '3.0'
   Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/RSpec/HaveSelector
 
 Capybara/RSpec/MatchStyle:
   Description: Checks for usage of deprecated style methods in RSpec matchers.
-  Enabled: pending
+  Enabled: true
   VersionAdded: '2.23'
+  VersionChanged: '3.0'
   Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/RSpec/MatchStyle
 
 Capybara/RSpec/NegationMatcher:
   Description: Enforces use of `have_no_*` or `not_to` for negated expectations.
-  Enabled: pending
+  Enabled: true
   VersionAdded: '2.14'
-  VersionChanged: '2.23'
+  VersionChanged: '3.0'
   EnforcedStyle: have_no
   SupportedStyles:
     - have_no
@@ -90,14 +97,14 @@ Capybara/RSpec/NegationMatcher:
 
 Capybara/RSpec/NegationMatcherAfterVisit:
   Description: Do not allow negative matchers to be used immediately after `visit`.
-  Enabled: pending
+  Enabled: true
   VersionAdded: '2.22'
-  VersionChanged: '2.23'
+  VersionChanged: '3.0'
   Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/RSpec/NegationMatcherAfterVisit
 
 Capybara/RSpec/PredicateMatcher:
   Description: Prefer using predicate matcher over using predicate method directly.
-  Enabled: pending
+  Enabled: true
   Strict: true
   EnforcedStyle: inflected
   AllowedExplicitMatchers: []
@@ -105,18 +112,19 @@ Capybara/RSpec/PredicateMatcher:
     - inflected
     - explicit
   VersionAdded: '2.19'
+  VersionChanged: '3.0'
   Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/RSpec/PredicateMatcher
 
 Capybara/RSpec/SpecificMatcher:
   Description: Checks for there is a more specific matcher offered by Capybara.
-  Enabled: pending
+  Enabled: true
   VersionAdded: '2.12'
-  VersionChanged: '2.23'
+  VersionChanged: '3.0'
   Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/RSpec/SpecificMatcher
 
 Capybara/RSpec/VisibilityMatcher:
   Description: Checks for boolean visibility in Capybara finders.
-  Enabled: pending
+  Enabled: true
   VersionAdded: '1.39'
-  VersionChanged: '2.23'
+  VersionChanged: '3.0'
   Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/RSpec/VisibilityMatcher

--- a/docs/modules/ROOT/pages/cops_capybara.adoc
+++ b/docs/modules/ROOT/pages/cops_capybara.adoc
@@ -49,11 +49,11 @@ click_button('foo')
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-| Pending
+| Enabled
 | Yes
 | Always
 | 2.23
-| -
+| 3.0
 |===
 
 Checks for usage of deprecated assert style method.
@@ -81,11 +81,11 @@ page.find(:css, '#first').assert_matches_style(display: 'block')
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-| Pending
+| Enabled
 | Yes
 | Always (Unsafe)
 | 2.22
-| 2.23
+| 3.0
 |===
 
 Enforces use of `first` instead of `all` with `first` or `[0]`.
@@ -125,11 +125,11 @@ first('a')
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-| Pending
+| Enabled
 | Yes
 | Always
 | 2.20
-| -
+| 3.0
 |===
 
 Checks for redundant `within find(...)` calls.
@@ -171,11 +171,11 @@ end
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-| Pending
+| Enabled
 | Yes
 | No
 | 2.14
-| -
+| 3.0
 |===
 
 Checks for there is a more specific actions offered by Capybara.
@@ -209,11 +209,11 @@ find('div').click_button
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-| Pending
+| Enabled
 | Yes
 | Always
 | 2.13
-| -
+| 3.0
 |===
 
 Checks if there is a more specific finder offered by Capybara.

--- a/docs/modules/ROOT/pages/cops_capybara_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_capybara_rspec.adoc
@@ -12,11 +12,11 @@
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-| Pending
+| Enabled
 | Yes
 | Always
 | 1.18
-| 2.23
+| 3.0
 |===
 
 Checks that no expectations are set on Capybara's `current_path`.
@@ -58,11 +58,11 @@ expect(page).to match(variable)
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-| Pending
+| Enabled
 | Yes
 | Always
 | 2.23
-| -
+| 3.0
 |===
 
 Checks for usage of `have_content` and `have_no_content`.
@@ -96,11 +96,11 @@ expect(page).to have_no_text('bara')
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-| Pending
+| Enabled
 | Yes
 | Always
 | 2.19
-| -
+| 3.0
 |===
 
 Use `have_css` or `have_xpath` instead of `have_selector`.
@@ -169,11 +169,11 @@ expect(foo).to have_xpath('bar')
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-| Pending
+| Enabled
 | Yes
 | Always
 | 2.23
-| -
+| 3.0
 |===
 
 Checks for usage of deprecated style methods in RSpec matchers.
@@ -218,11 +218,11 @@ expect(page).to match_style(display: 'block')
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-| Pending
+| Enabled
 | Yes
 | Always
 | 2.14
-| 2.23
+| 3.0
 |===
 
 Enforces use of `have_no_*` or `not_to` for negated expectations.
@@ -280,11 +280,11 @@ expect(page).not_to have_css('a')
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-| Pending
+| Enabled
 | Yes
 | No
 | 2.22
-| 2.23
+| 3.0
 |===
 
 Do not allow negative matchers to be used immediately after `visit`.
@@ -326,11 +326,11 @@ expect(page).not_to have_link('bar')
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-| Pending
+| Enabled
 | Yes
 | Always
 | 2.19
-| -
+| 3.0
 |===
 
 Prefer using predicate matcher over using predicate method directly.
@@ -430,11 +430,11 @@ expect(foo.matches_style?(bar: 'baz')).to be_truthy
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-| Pending
+| Enabled
 | Yes
 | No
 | 2.12
-| 2.23
+| 3.0
 |===
 
 Checks for there is a more specific matcher offered by Capybara.
@@ -474,11 +474,11 @@ expect(page).to have_field(with: 'foo')
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-| Pending
+| Enabled
 | Yes
 | No
 | 1.39
-| 2.23
+| 3.0
 |===
 
 Checks for boolean visibility in Capybara finders.


### PR DESCRIPTION
Fixes: https://github.com/rubocop/rubocop-capybara/issues/81

- Enable pending Capybara cops by default for 3.0
- Mark their VersionChanged as 3.0
- Regenerate cops documentation