### PR TITLE
Update SpecificMatcher README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ In your `.rubocop.yml`, you may treat the Capybara cops just like any other
 cop. For example:
 
 ```yaml
-Capybara/SpecificMatcher:
+Capybara/RSpec/SpecificMatcher:
   Exclude:
     - spec/my_spec.rb
 ```


### PR DESCRIPTION
Update the README configuration example to use `Capybara/RSpec/SpecificMatcher`.
