### PR TITLE
Fix a false negative for `Capybara/RSpec/NegationMatcherAfterVisit` when using `to_not`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Edge (Unreleased)
 
+- Fix a false negative for `Capybara/RSpec/NegationMatcherAfterVisit` when using `to_not`. ([@ydah])
+
 ## 3.0.0 (2026-06-22)
 
 - Enable pending cops by default for the 3.0 release. ([@ydah])

--- a/lib/rubocop/cop/capybara/rspec/negation_matcher_after_visit.rb
+++ b/lib/rubocop/cop/capybara/rspec/negation_matcher_after_visit.rb
@@ -37,7 +37,7 @@ module RuboCop
           def_node_matcher :negation_matcher?, <<~PATTERN
             {
               (send (send nil? :expect _) :to (send nil? %NEGATIVE_MATCHERS ...))
-              (send (send nil? :expect _) :not_to (send nil? %POSITIVE_MATCHERS ...))
+              (send (send nil? :expect _) {:not_to :to_not} (send nil? %POSITIVE_MATCHERS ...))
             }
           PATTERN
 

--- a/spec/rubocop/cop/capybara/rspec/negation_matcher_after_visit_spec.rb
+++ b/spec/rubocop/cop/capybara/rspec/negation_matcher_after_visit_spec.rb
@@ -20,6 +20,15 @@ RSpec.describe RuboCop::Cop::Capybara::RSpec::NegationMatcherAfterVisit,
     RUBY
   end
 
+  it 'registers an offense when using `to_not` with `have_*` after ' \
+     'immediately `visit` method call' do
+    expect_offense(<<~RUBY)
+      visit foo_path
+      expect(page).to_not have_link('bar')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use negation matcher immediately after visit.
+    RUBY
+  end
+
   it 'does not register an offense when using positive matchers after ' \
      'immediately `visit` method call' do
     expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fix a false negative for `Capybara/RSpec/NegationMatcherAfterVisit` when using `to_not`.

`NegationMatcherAfterVisit` already handled `not_to` after `visit`, but missed the equivalent RSpec `to_not` alias. This adds `to_not` to the matcher pattern and covers the case with a regression spec.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [-] Added the new cop to `config/default.yml`.
- [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [-] The cop documents examples of good and bad code.
- [-] The tests assert both that bad code is reported and that good code is not reported.
- [-] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [-] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
