### PR TITLE
Fix an incorrect autocorrect for `Capybara/RSpec/PredicateMatcher` with complex actual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Edge (Unreleased)
 
 - Fix a false negative for `Capybara/RSpec/NegationMatcherAfterVisit` when using `to_not`. ([@ydah])
+- Fix an incorrect autocorrect for `Capybara/RSpec/PredicateMatcher` when `EnforcedStyle: explicit` and `expect` actual is a complex expression. ([@ydah])
 
 ## 3.0.0 (2026-06-22)
 

--- a/lib/rubocop/cop/capybara/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/capybara/rspec/predicate_matcher.rb
@@ -118,6 +118,12 @@ module RuboCop
           INFLECTED_MATCHER = %w[css selector style xpath].each.map do |suffix|
             "match_#{suffix}"
           end.freeze
+          SAFE_RECEIVER_TYPES = Set.new(
+            %i[
+              array complex dstr false float hash int nil rational regexp str
+              sym true xstr
+            ]
+          ).freeze
 
           private
 
@@ -169,12 +175,38 @@ module RuboCop
           def move_predicate(corrector, actual, matcher)
             predicate = to_predicate_method(matcher.method_name)
             args = args_loc(matcher).source
-            corrector.insert_after(actual,
-                                   ".#{predicate}" + args)
+            replacement = ".#{predicate}#{args}"
+
+            if actual_requires_parentheses?(actual)
+              corrector.replace(actual, "(#{actual.source})#{replacement}")
+            else
+              corrector.insert_after(actual, replacement)
+            end
           end
 
           def to_predicate_method(matcher)
             "#{matcher.to_s.sub('match_', 'matches_')}?"
+          end
+
+          def actual_requires_parentheses?(actual)
+            return false if actual.begin_type?
+
+            if actual.call_type?
+              return actual_send_requires_parentheses?(actual)
+            end
+
+            !literal_receiver?(actual)
+          end
+
+          def actual_send_requires_parentheses?(actual)
+            return false if actual.method?(:[])
+
+            actual.operator_method? ||
+              (actual.arguments? && !actual.parenthesized?)
+          end
+
+          def literal_receiver?(actual)
+            SAFE_RECEIVER_TYPES.include?(actual.type)
           end
 
           # rubocop:disable Metrics/MethodLength

--- a/spec/rubocop/cop/capybara/rspec/predicate_matcher_spec.rb
+++ b/spec/rubocop/cop/capybara/rspec/predicate_matcher_spec.rb
@@ -102,6 +102,62 @@ RSpec.describe RuboCop::Cop::Capybara::RSpec::PredicateMatcher, :config do
         RUBY
       end
 
+      it 'wraps complex actual expressions during autocorrection' do
+        expect_offense(<<~RUBY)
+          expect(foo || bar).to match_css(bar: 'baz')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `matches_css?` over `match_css` matcher.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          expect((foo || bar).matches_css?(bar: 'baz')).to #{matcher_true}
+        RUBY
+      end
+
+      it 'wraps operator method actual expressions during autocorrection' do
+        expect_offense(<<~RUBY)
+          expect(foo + bar).to match_css(bar: 'baz')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `matches_css?` over `match_css` matcher.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          expect((foo + bar).matches_css?(bar: 'baz')).to #{matcher_true}
+        RUBY
+      end
+
+      it 'wraps unparenthesized method call actual expressions during ' \
+         'autocorrection' do
+        expect_offense(<<~RUBY)
+          expect(foo bar).to match_css(bar: 'baz')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `matches_css?` over `match_css` matcher.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          expect((foo bar).matches_css?(bar: 'baz')).to #{matcher_true}
+        RUBY
+      end
+
+      it 'does not wrap parenthesized complex actual expressions again' do
+        expect_offense(<<~RUBY)
+          expect((foo || bar)).to match_css(bar: 'baz')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `matches_css?` over `match_css` matcher.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          expect((foo || bar).matches_css?(bar: 'baz')).to #{matcher_true}
+        RUBY
+      end
+
+      it 'does not wrap literal actual expressions' do
+        expect_offense(<<~RUBY)
+          expect('foo').to match_css(bar: 'baz')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `matches_css?` over `match_css` matcher.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          expect('foo'.matches_css?(bar: 'baz')).to #{matcher_true}
+        RUBY
+      end
+
       context 'when `AllowedExplicitMatchers: match_xpath`' do
         let(:allowed_explicit_matchers) { ['match_xpath'] }
 


### PR DESCRIPTION
Fix an incorrect autocorrect for `Capybara/RSpec/PredicateMatcher` when `EnforcedStyle: explicit` and the `expect` actual is a complex expression.

The previous autocorrect appended `matches_*?` directly to the actual node. For code like `expect(foo || bar).to match_css(...)`, that produced `expect(foo || bar.matches_css?(...)).to ...`, changing which expression receives the predicate call. This wraps complex actual expressions before appending the predicate call and adds regression coverage for the affected shapes.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [-] Added the new cop to `config/default.yml`.
- [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [-] The cop documents examples of good and bad code.
- [-] The tests assert both that bad code is reported and that good code is not reported.
- [-] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [-] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
