### PR TITLE
Fix a false positive for `Capybara/SpecificActions` when `click` uses arguments or a block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix a false negative for `Capybara/RSpec/NegationMatcherAfterVisit` when using `to_not`. ([@ydah])
 - Fix an incorrect autocorrect for `Capybara/RSpec/PredicateMatcher` when `EnforcedStyle: explicit` and `expect` actual is a complex expression. ([@ydah])
+- Fix a false positive for `Capybara/SpecificActions` when `click` uses arguments or a block. ([@ydah])
 
 ## 3.0.0 (2026-06-22)
 

--- a/lib/rubocop/cop/capybara/specific_actions.rb
+++ b/lib/rubocop/cop/capybara/specific_actions.rb
@@ -33,6 +33,8 @@ module RuboCop
         PATTERN
 
         def on_send(node)
+          return if node.arguments? || node.block_node
+
           click_on_selector(node.receiver) do |arg|
             next unless supported_selector?(arg)
             # Always check the last selector in the case of multiple selectors

--- a/spec/rubocop/cop/capybara/specific_actions_spec.rb
+++ b/spec/rubocop/cop/capybara/specific_actions_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificActions do
     RUBY
   end
 
+  it 'does not register an offense when using find and click action ' \
+     'with click arguments or block' do
+    expect_no_offenses(<<~RUBY)
+      find('a', href: 'http://example.com').click(:middle)
+      find('button').click { |element| element[:id] }
+    RUBY
+  end
+
   it 'registers an offense when using find and click action when ' \
      'first argument is button' do
     expect_offense(<<~RUBY)


### PR DESCRIPTION
Fix a false positive for `Capybara/SpecificActions` when `click` uses arguments or a block.

`SpecificActions` previously inspected only the receiver of `.click`, so it flagged cases like `find('a').click(:middle)` and block-form `click`. Those calls are not necessarily equivalent to `click_link` or `click_button`, so this skips `.click` calls that have arguments or a block.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [-] Added the new cop to `config/default.yml`.
- [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [-] The cop documents examples of good and bad code.
- [-] The tests assert both that bad code is reported and that good code is not reported.
- [-] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [-] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
