### PR TITLE
Fix an incorrect autocorrect for `Capybara/SpecificFinders` with nested `class:` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix a false negative for `Capybara/RSpec/NegationMatcherAfterVisit` when using `to_not`. ([@ydah])
 - Fix an incorrect autocorrect for `Capybara/RSpec/PredicateMatcher` when `EnforcedStyle: explicit` and `expect` actual is a complex expression. ([@ydah])
 - Fix a false positive for `Capybara/SpecificActions` when `click` uses arguments or a block. ([@ydah])
+- Fix an incorrect autocorrect for `Capybara/SpecificFinders` when a selector class is used with nested `class:` options. ([@ydah])
 
 ## 3.0.0 (2026-06-22)
 

--- a/lib/rubocop/cop/capybara/specific_finders.rb
+++ b/lib/rubocop/cop/capybara/specific_finders.rb
@@ -27,9 +27,9 @@ module RuboCop
           (send _ :find $(sym {:css :id})? (str $_) ...)
         PATTERN
 
-        # @!method class_options(node)
-        def_node_search :class_options, <<~PATTERN
-          (pair (sym :class) $_ ...)
+        # @!method class_option(node)
+        def_node_matcher :class_option, <<~PATTERN
+          (send _ :find ... (hash <(pair (sym :class) $_) ...>))
         PATTERN
 
         def on_send(node)
@@ -87,7 +87,7 @@ module RuboCop
         end
 
         def autocorrect_classes(corrector, node, classes)
-          if (options = class_options(node).first)
+          if (options = class_option(node))
             append_options(classes, options)
             corrector.replace(options, classes.to_s)
           else

--- a/spec/rubocop/cop/capybara/specific_finders_spec.rb
+++ b/spec/rubocop/cop/capybara/specific_finders_spec.rb
@@ -150,6 +150,18 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificFinders do
     RUBY
   end
 
+  it 'registers an offense when using `find` with an id, class, ' \
+     'and nested class option' do
+    expect_offense(<<~RUBY)
+      find('#some-id.some-cls', data: { class: 'nested-cls' })
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by_id` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id', class: 'some-cls', data: { class: 'nested-cls' })
+    RUBY
+  end
+
   it 'registers an offense when using `find` and other args' do
     expect_offense(<<~RUBY)
       find('#some-id', exact_text: 'foo')


### PR DESCRIPTION
Fix an incorrect autocorrect for `Capybara/SpecificFinders` with nested `class:` options.

`SpecificFinders` previously searched every descendant `class:` pair when merging selector classes into options. That meant a call such as `find('#some-id.some-cls', data: { class: 'nested-cls' })` could incorrectly rewrite the nested `data[:class]` value.

This changes the cop to only reuse a top-level `class:` option from the `find` call's keyword hash. Nested `class:` keys are left untouched, and selector classes are inserted as a separate top-level option when needed.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [-] Added the new cop to `config/default.yml`.
- [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [-] The cop documents examples of good and bad code.
- [-] The tests assert both that bad code is reported and that good code is not reported.
- [-] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [-] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
