### PR TITLE
Fix the `Capybara/RSpec/CurrentPathExpectation` variable match example

### DIFF
--- a/docs/modules/ROOT/pages/cops_capybara_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_capybara_rspec.adoc
@@ -44,7 +44,7 @@ expect(page.current_path).to eq('/callback')
 expect(page).to have_current_path('/callback', ignore_query: true)
 
 # bad (does not support autocorrection when `match` with a variable)
-expect(page).to match(variable)
+expect(current_path).to match(variable)
 ----
 
 [#references-capybararspeccurrentpathexpectation]

--- a/lib/rubocop/cop/capybara/rspec/current_path_expectation.rb
+++ b/lib/rubocop/cop/capybara/rspec/current_path_expectation.rb
@@ -25,7 +25,7 @@ module RuboCop
         #   expect(page).to have_current_path('/callback', ignore_query: true)
         #
         #   # bad (does not support autocorrection when `match` with a variable)
-        #   expect(page).to match(variable)
+        #   expect(current_path).to match(variable)
         #
         class CurrentPathExpectation < ::RuboCop::Cop::Base
           extend AutoCorrector


### PR DESCRIPTION
Fix the `Capybara/RSpec/CurrentPathExpectation` variable match example.

The example for unsupported autocorrection with `match(variable)` used `expect(page).to match(variable)`, but this cop only detects expectations set on `current_path`. This updates the source comment and generated documentation to use `expect(current_path).to match(variable)` instead.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [x] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [-] Added the new cop to `config/default.yml`.
- [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [-] The cop documents examples of good and bad code.
- [-] The tests assert both that bad code is reported and that good code is not reported.
- [-] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [-] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
