### PR TITLE
Add new `Capybara/RSpec/FindElementValueEq` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Edge (Unreleased)
 
+- Add new `Capybara/RSpec/FindElementValueEq` cop. ([@ydah])
 - Fix a false negative for `Capybara/RSpec/NegationMatcherAfterVisit` when using `to_not`. ([@ydah])
 - Fix an incorrect autocorrect for `Capybara/RSpec/PredicateMatcher` when `EnforcedStyle: explicit` and `expect` actual is a complex expression. ([@ydah])
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -62,6 +62,13 @@ Capybara/RSpec/CurrentPathExpectation:
   VersionChanged: '3.0'
   Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/RSpec/CurrentPathExpectation
 
+Capybara/RSpec/FindElementValueEq:
+  Description: Checks for expectations on the value of an element found by Capybara.
+  Enabled: pending
+  SafeAutoCorrect: false
+  VersionAdded: "<<next>>"
+  Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/RSpec/FindElementValueEq
+
 Capybara/RSpec/HaveContent:
   Description: Checks for usage of `have_content` and `have_no_content`.
   Enabled: true

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -12,6 +12,7 @@
 === Department xref:cops_capybara_rspec.adoc[Capybara/RSpec]
 
 * xref:cops_capybara_rspec.adoc#capybararspeccurrentpathexpectation[Capybara/RSpec/CurrentPathExpectation]
+* xref:cops_capybara_rspec.adoc#capybararspecfindelementvalueeq[Capybara/RSpec/FindElementValueEq]
 * xref:cops_capybara_rspec.adoc#capybararspechavecontent[Capybara/RSpec/HaveContent]
 * xref:cops_capybara_rspec.adoc#capybararspechaveselector[Capybara/RSpec/HaveSelector]
 * xref:cops_capybara_rspec.adoc#capybararspecmatchstyle[Capybara/RSpec/MatchStyle]

--- a/docs/modules/ROOT/pages/cops_capybara_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_capybara_rspec.adoc
@@ -52,6 +52,48 @@ expect(page).to match(variable)
 
 * https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/RSpec/CurrentPathExpectation
 
+[#capybararspecfindelementvalueeq]
+== Capybara/RSpec/FindElementValueEq
+
+|===
+| Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
+
+| Pending
+| Yes
+| Always (Unsafe)
+| <<next>>
+| -
+|===
+
+Checks for expectations on the value of an element found by Capybara.
+
+[#safety-capybararspecfindelementvalueeq]
+=== Safety
+
+This cop's autocorrection is unsafe because `find('input').value`
+checks the value of the first matched element, while `have_field`
+checks that any field on the page has the expected value.
+
+[#examples-capybararspecfindelementvalueeq]
+=== Examples
+
+[source,ruby]
+----
+# bad
+expect(find('input').value).to eq('foobar')
+expect(find(:css, 'input').value).to eq('foobar')
+expect(find_field('Email').value).to eq('user@example.com')
+
+# good
+expect(page).to have_field(with: 'foobar')
+expect(page).to have_field('Email', with: 'user@example.com')
+----
+
+[#references-capybararspecfindelementvalueeq]
+=== References
+
+* https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/RSpec/FindElementValueEq
+
 [#capybararspechavecontent]
 == Capybara/RSpec/HaveContent
 

--- a/lib/rubocop/cop/capybara/rspec/find_element_value_eq.rb
+++ b/lib/rubocop/cop/capybara/rspec/find_element_value_eq.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Capybara
+      module RSpec
+        # Checks for expectations on the value of an element found by Capybara.
+        #
+        # @safety
+        #   This cop's autocorrection is unsafe because `find('input').value`
+        #   checks the value of the first matched element, while `have_field`
+        #   checks that any field on the page has the expected value.
+        #
+        # @example
+        #   # bad
+        #   expect(find('input').value).to eq('foobar')
+        #   expect(find(:css, 'input').value).to eq('foobar')
+        #   expect(find_field('Email').value).to eq('user@example.com')
+        #
+        #   # good
+        #   expect(page).to have_field(with: 'foobar')
+        #   expect(page).to have_field('Email', with: 'user@example.com')
+        #
+        class FindElementValueEq < ::RuboCop::Cop::Base
+          extend AutoCorrector
+
+          MSG = 'Prefer `have_field` over checking `find(...).value`.'
+          RESTRICT_ON_SEND = %i[expect].freeze
+          FIELD_ELEMENT_SELECTORS = %w[input textarea].freeze
+
+          # @!method find_element_value_eq(node)
+          def_node_matcher :find_element_value_eq, <<~PATTERN
+            (send
+              (send nil? :expect (send $_ :value))
+              ${:to :to_not :not_to}
+              $(send nil? :eq $_)
+            )
+          PATTERN
+
+          def on_send(node)
+            find_element_value_eq(node.parent) do |finder, to_symbol,
+                                                   matcher, expected|
+              register_offense(node, finder, to_symbol, matcher, expected)
+            end
+          end
+          alias on_csend on_send
+
+          private
+
+          def register_offense(node, finder, to_symbol, matcher, expected)
+            replacement = replacement_for_finder(finder)
+            return unless replacement
+
+            expect_target, field_locator = replacement
+            matcher_replacement =
+              replacement_matcher(to_symbol, expected, field_locator)
+
+            add_offense(node.loc.selector) do |corrector|
+              autocorrect(corrector, node, matcher, expect_target,
+                          matcher_replacement)
+            end
+          end
+
+          def replacement_for_finder(node)
+            return unless node&.send_type?
+
+            case node.method_name
+            when :find
+              replacement_for_find(node)
+            when :find_field
+              replacement_for_find_field(node)
+            end
+          end
+
+          def replacement_for_find(node)
+            if (field_locator = field_selector_locator(node.arguments))
+              return [expect_target(node), field_locator]
+            end
+
+            return unless field_element_selector?(node.arguments)
+
+            [expect_target(node), nil]
+          end
+
+          def replacement_for_find_field(node)
+            return unless node.arguments.one?
+
+            [expect_target(node), node.first_argument]
+          end
+
+          def field_element_selector?(arguments)
+            return field_element_name?(arguments.first) if arguments.one?
+
+            arguments.length == 2 &&
+              arguments.first.sym_type? &&
+              arguments.first.value == :css &&
+              field_element_name?(arguments.last)
+          end
+
+          def field_selector_locator(arguments)
+            return unless arguments.length == 2
+
+            selector_type, locator = arguments
+            return unless field_selector?(selector_type)
+
+            locator
+          end
+
+          def field_selector?(node)
+            node.sym_type? && node.value == :field
+          end
+
+          def field_element_name?(node)
+            node.str_type? && FIELD_ELEMENT_SELECTORS.include?(node.value)
+          end
+
+          def expect_target(node)
+            node.receiver&.source || 'page'
+          end
+
+          def autocorrect(corrector, node, matcher, expect_target,
+                          matcher_replacement)
+            corrector.replace(node.first_argument, expect_target)
+            corrector.replace(node.parent.loc.selector, 'to')
+            corrector.replace(matcher, matcher_replacement)
+          end
+
+          def replacement_matcher(to_symbol, expected, field_locator)
+            matcher = to_symbol == :to ? 'have_field' : 'have_no_field'
+            args = ["with: #{replacement_value(expected)}"]
+            args.unshift(replacement_value(field_locator)) if field_locator
+
+            "#{matcher}(#{args.join(', ')})"
+          end
+
+          def replacement_value(expected)
+            if method_call_with_no_parentheses?(expected)
+              return "(#{expected.source})"
+            end
+
+            expected.source
+          end
+
+          def method_call_with_no_parentheses?(node)
+            node.send_type? && node.arguments? && !node.parenthesized?
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/capybara_cops.rb
+++ b/lib/rubocop/cop/capybara_cops.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'capybara/rspec/current_path_expectation'
+require_relative 'capybara/rspec/find_element_value_eq'
 require_relative 'capybara/rspec/have_content'
 require_relative 'capybara/rspec/have_selector'
 require_relative 'capybara/rspec/match_style'

--- a/spec/rubocop/cop/capybara/rspec/find_element_value_eq_spec.rb
+++ b/spec/rubocop/cop/capybara/rspec/find_element_value_eq_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Capybara::RSpec::FindElementValueEq do
+  it 'registers an offense when using `find` element value with `eq`' do
+    expect_offense(<<~RUBY)
+      expect(find('input').value).to eq('foobar')
+      ^^^^^^ Prefer `have_field` over checking `find(...).value`.
+      expect(find(:css, 'input').value).to eq('foobar')
+      ^^^^^^ Prefer `have_field` over checking `find(...).value`.
+      expect(find('textarea').value).to eq('foobar')
+      ^^^^^^ Prefer `have_field` over checking `find(...).value`.
+      expect(find(:css, 'textarea').value).to eq('foobar')
+      ^^^^^^ Prefer `have_field` over checking `find(...).value`.
+      expect(page.find('input').value).to eq('foobar')
+      ^^^^^^ Prefer `have_field` over checking `find(...).value`.
+      expect(page.find(:css, 'input').value).to eq('foobar')
+      ^^^^^^ Prefer `have_field` over checking `find(...).value`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expect(page).to have_field(with: 'foobar')
+      expect(page).to have_field(with: 'foobar')
+      expect(page).to have_field(with: 'foobar')
+      expect(page).to have_field(with: 'foobar')
+      expect(page).to have_field(with: 'foobar')
+      expect(page).to have_field(with: 'foobar')
+    RUBY
+  end
+
+  it 'preserves receiver when using scoped `find` element value with `eq`' do
+    expect_offense(<<~RUBY)
+      expect(container.find('input').value).to eq('foobar')
+      ^^^^^^ Prefer `have_field` over checking `find(...).value`.
+      expect(container.find(:css, 'input').value).to eq('foobar')
+      ^^^^^^ Prefer `have_field` over checking `find(...).value`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expect(container).to have_field(with: 'foobar')
+      expect(container).to have_field(with: 'foobar')
+    RUBY
+  end
+
+  it 'registers an offense when using `find_field` value with `eq`' do
+    expect_offense(<<~RUBY)
+      expect(find_field('Email').value).to eq('user@example.com')
+      ^^^^^^ Prefer `have_field` over checking `find(...).value`.
+      expect(find(:field, 'Email').value).to eq('user@example.com')
+      ^^^^^^ Prefer `have_field` over checking `find(...).value`.
+      expect(page.find_field('Email').value).to eq('user@example.com')
+      ^^^^^^ Prefer `have_field` over checking `find(...).value`.
+      expect(page.find(:field, 'Email').value).to eq('user@example.com')
+      ^^^^^^ Prefer `have_field` over checking `find(...).value`.
+      expect(container.find_field('Email').value).to eq('user@example.com')
+      ^^^^^^ Prefer `have_field` over checking `find(...).value`.
+      expect(container.find(:field, 'Email').value).to eq('user@example.com')
+      ^^^^^^ Prefer `have_field` over checking `find(...).value`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expect(page).to have_field('Email', with: 'user@example.com')
+      expect(page).to have_field('Email', with: 'user@example.com')
+      expect(page).to have_field('Email', with: 'user@example.com')
+      expect(page).to have_field('Email', with: 'user@example.com')
+      expect(container).to have_field('Email', with: 'user@example.com')
+      expect(container).to have_field('Email', with: 'user@example.com')
+    RUBY
+  end
+
+  it 'registers an offense when using negated `find` element value with `eq`' do
+    expect_offense(<<~RUBY)
+      expect(find('input').value).not_to eq('foobar')
+      ^^^^^^ Prefer `have_field` over checking `find(...).value`.
+      expect(find('input').value).to_not eq('foobar')
+      ^^^^^^ Prefer `have_field` over checking `find(...).value`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expect(page).to have_no_field(with: 'foobar')
+      expect(page).to have_no_field(with: 'foobar')
+    RUBY
+  end
+
+  it 'preserves non-literal expected values' do
+    expect_offense(<<~RUBY)
+      expect(find('input').value).to eq(expected_value)
+      ^^^^^^ Prefer `have_field` over checking `find(...).value`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expect(page).to have_field(with: expected_value)
+    RUBY
+  end
+
+  it 'wraps method call expected values without parentheses ' \
+     'during autocorrection' do
+    expect_offense(<<~RUBY)
+      expect(find('input').value).to eq(expected_value :foo)
+      ^^^^^^ Prefer `have_field` over checking `find(...).value`.
+      expect(find_field(field_name :email).value).to eq('user@example.com')
+      ^^^^^^ Prefer `have_field` over checking `find(...).value`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expect(page).to have_field(with: (expected_value :foo))
+      expect(page).to have_field((field_name :email), with: 'user@example.com')
+    RUBY
+  end
+
+  it 'does not register an offense when value expectation is not replaceable' do
+    expect_no_offenses(<<~RUBY)
+      expect(find('input.foo').value).to eq('foobar')
+      expect(find('input', visible: false).value).to eq('foobar')
+      expect(find_field('Email', disabled: true).value).to eq('foobar')
+      expect(find('input').text).to eq('foobar')
+      expect(find('input').value).to eql('foobar')
+      expect(value).to eq('foobar')
+    RUBY
+  end
+end


### PR DESCRIPTION
Fixes: https://github.com/rubocop/rubocop-capybara/issues/5

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [x] Added the new cop to `config/default.yml`.
- [x] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [x] The cop documents examples of good and bad code.
- [x] The tests assert both that bad code is reported and that good code is not reported.
- [x] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [-] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
