### PR TITLE
Fix CSS attribute parsing for values with equals signs

### DIFF
--- a/lib/rubocop/cop/capybara/mixin/css_attributes_parser.rb
+++ b/lib/rubocop/cop/capybara/mixin/css_attributes_parser.rb
@@ -43,7 +43,7 @@ module RuboCop
           @bracket_count -= 1
           if @bracket_count.zero?
             @state = :initial
-            key, value = @temp.split('=')
+            key, value = @temp.split('=', 2)
             @results[key] = normalize_value(value)
             @temp.clear
           else

--- a/spec/rubocop/cop/capybara/mixin/css_attributes_parser_spec.rb
+++ b/spec/rubocop/cop/capybara/mixin/css_attributes_parser_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe RuboCop::Cop::Capybara::CssAttributesParser do
       )
     end
 
+    it 'returns attributes hash when attribute value contains equals sign' do
+      expect(
+        described_class.new('a[href="https://example.test?a=b"]').parse
+      ).to eq('href' => "'https://example.test?a=b'")
+    end
+
     it 'returns attributes hash when specify multiple attributes' do
       expect(described_class.new('button[foo][bar=baz]').parse).to eq(
         'foo' => nil, 'bar' => "'baz'"

--- a/spec/rubocop/cop/capybara/mixin/css_selector_spec.rb
+++ b/spec/rubocop/cop/capybara/mixin/css_selector_spec.rb
@@ -78,6 +78,12 @@ RSpec.describe RuboCop::Cop::Capybara::CssSelector do
       )
     end
 
+    it 'returns attributes hash when attribute value contains equals sign' do
+      expect(
+        described_class.attributes('a[href="https://example.test?a=b"]')
+      ).to eq('href' => "'https://example.test?a=b'")
+    end
+
     it 'returns attributes hash when specify multiple attributes' do
       expect(described_class.attributes('button[foo][bar=baz]')).to eq(
         'foo' => nil, 'bar' => "'baz'"


### PR DESCRIPTION
Fix CSS attribute values that contain `=` by splitting the attribute pair at only the first equals sign.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [-] Added the new cop to `config/default.yml`.
- [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [-] The cop documents examples of good and bad code.
- [-] The tests assert both that bad code is reported and that good code is not reported.
- [-] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [-] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
