### PR TITLE
Fix CSS attribute parsing for quoted values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix an incorrect autocorrect for `Capybara/RSpec/PredicateMatcher` when `EnforcedStyle: explicit` and `expect` actual is a complex expression. ([@ydah])
 - Fix a false positive for `Capybara/SpecificActions` when `click` uses arguments or a block. ([@ydah])
 - Fix an incorrect autocorrect for `Capybara/SpecificFinders` when a selector class is used with nested `class:` options. ([@ydah])
+- Fix CSS attribute parsing when attribute values contain quotes. ([@ydah])
 
 ## 3.0.0 (2026-06-22)
 

--- a/lib/rubocop/cop/capybara/mixin/css_attributes_parser.rb
+++ b/lib/rubocop/cop/capybara/mixin/css_attributes_parser.rb
@@ -6,6 +6,8 @@ module RuboCop
       # Css selector parser.
       # @api private
       class CssAttributesParser
+        QUOTE_CHARS = ['"', "'"].freeze
+
         def initialize(selector)
           @selector = selector
           @state = :initial
@@ -63,8 +65,25 @@ module RuboCop
           when 'true' then true
           when 'false' then false
           when nil then nil
-          else "'#{value.gsub(/"|'/, '')}'"
+          else "'#{escape_single_quotes(strip_outer_quotes(value))}'"
           end
+        end
+
+        def strip_outer_quotes(value)
+          return value unless quoted?(value)
+
+          value[1...-1]
+        end
+
+        def quoted?(value)
+          return false if value.length < 2
+
+          quote = value[0]
+          QUOTE_CHARS.include?(quote) && value.end_with?(quote)
+        end
+
+        def escape_single_quotes(value)
+          value.gsub("'", "\\\\'")
         end
       end
     end

--- a/lib/rubocop/cop/capybara/specific_finders.rb
+++ b/lib/rubocop/cop/capybara/specific_finders.rb
@@ -57,12 +57,12 @@ module RuboCop
           return if CssSelector.attributes(arg).any?
 
           id = CssSelector.id(arg)
-          register_offense(node, sym, "'#{id}'",
+          register_offense(node, sym, "'#{id.delete('\\')}'",
                            CssSelector.classes(arg.sub("##{id}", '')))
         end
 
         def on_sym_id(node, sym, id)
-          register_offense(node, sym, "'#{id}'")
+          register_offense(node, sym, "'#{id.delete('\\')}'")
         end
 
         def attribute?(arg)
@@ -70,10 +70,10 @@ module RuboCop
             CapybaraHelp.common_attributes?(arg)
         end
 
-        def register_offense(node, sym, id, classes = [])
+        def register_offense(node, sym, replacement, classes = [])
           add_offense(offense_range(node)) do |corrector|
             corrector.replace(node.loc.selector, 'find_by_id')
-            corrector.replace(node.first_argument, id.delete('\\'))
+            corrector.replace(node.first_argument, replacement)
             unless classes.compact.empty?
               autocorrect_classes(corrector, node, classes)
             end
@@ -107,6 +107,7 @@ module RuboCop
         end
 
         def replaced_arguments(arg, id)
+          id = id.delete('\\')
           options = to_options(CssSelector.attributes(arg))
           options.empty? ? id : "#{id}, #{options}"
         end

--- a/spec/rubocop/cop/capybara/mixin/css_attributes_parser_spec.rb
+++ b/spec/rubocop/cop/capybara/mixin/css_attributes_parser_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe RuboCop::Cop::Capybara::CssAttributesParser do
       )
     end
 
+    it 'returns attributes hash when attribute value contains quotes' do
+      expect(described_class.new(%q([title="Bob's book"])).parse).to eq(
+        'title' => %q('Bob\'s book')
+      )
+      expect(described_class.new(%q([title='Say "hi"'])).parse).to eq(
+        'title' => %q('Say "hi"')
+      )
+    end
+
     it 'returns attributes hash when specify nested and include ' \
        'multiple bracket' do
       expect(described_class.new('[foo="bar[baz][qux]"]').parse).to eq(

--- a/spec/rubocop/cop/capybara/mixin/css_selector_spec.rb
+++ b/spec/rubocop/cop/capybara/mixin/css_selector_spec.rb
@@ -90,6 +90,15 @@ RSpec.describe RuboCop::Cop::Capybara::CssSelector do
       )
     end
 
+    it 'returns attributes hash when attribute value contains quotes' do
+      expect(described_class.attributes(%q([title="Bob's book"]))).to eq(
+        'title' => %q('Bob\'s book')
+      )
+      expect(described_class.attributes(%q([title='Say "hi"']))).to eq(
+        'title' => %q('Say "hi"')
+      )
+    end
+
     it 'returns attributes hash when specify nested and include ' \
        'multiple bracket' do
       expect(described_class.attributes('[foo="bar[baz][qux]"]')).to eq(

--- a/spec/rubocop/cop/capybara/specific_finders_spec.rb
+++ b/spec/rubocop/cop/capybara/specific_finders_spec.rb
@@ -249,6 +249,17 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificFinders do
     RUBY
   end
 
+  it 'preserves quotes inside attribute values during autocorrection' do
+    expect_offense(<<~RUBY)
+      find('[id=some-id][style="font-family:\\'Inter\\'"]')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by_id` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id', style: 'font-family:\\'Inter\\'')
+    RUBY
+  end
+
   it 'does not register an offense when using `find ' \
      'with argument is attribute not specified id' do
     expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fix CSS attribute parsing so only the outer matching quotes are removed from attribute values, while quote characters inside the value are preserved. This also keeps escaped quotes intact when `Capybara/SpecificFinders` autocorrects selector attributes into keyword arguments.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [-] Added the new cop to `config/default.yml`.
- [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [-] The cop documents examples of good and bad code.
- [-] The tests assert both that bad code is reported and that good code is not reported.
- [-] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [-] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
