### PR TITLE
Fix CSS attribute parsing to return raw values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix an incorrect autocorrect for `Capybara/SpecificFinders` when a selector class is used with nested `class:` options. ([@ydah])
 - Fix CSS attribute parsing when attribute values contain quotes. ([@ydah])
 - Add support for using `find` with `:link` and `:field` in `Capybara/SpecificFinders` cop. ([@ydah])
+- Fix CSS attribute parsing to return raw values and format Ruby literals in autocorrection. ([@ydah])
 
 ## 3.0.0 (2026-06-22)
 

--- a/lib/rubocop/cop/capybara/mixin/css_attributes_parser.rb
+++ b/lib/rubocop/cop/capybara/mixin/css_attributes_parser.rb
@@ -16,7 +16,7 @@ module RuboCop
           @bracket_count = 0
         end
 
-        # @return [Array<String>]
+        # @return [Hash<String, String, Boolean, nil>]
         def parse # rubocop:disable Metrics/MethodLength
           @selector.each_char do |char|
             if char == '['
@@ -54,18 +54,19 @@ module RuboCop
         end
 
         # @param value [String]
-        # @return [Boolean, String]
+        # @return [Boolean, String, nil]
         # @example
         #   normalize_value('true') # => true
         #   normalize_value('false') # => false
         #   normalize_value(nil) # => nil
-        #   normalize_value("foo") # => "'foo'"
+        #   normalize_value("foo") # => "foo"
+        #   normalize_value("'foo'") # => "foo"
         def normalize_value(value)
           case value
           when 'true' then true
           when 'false' then false
           when nil then nil
-          else "'#{escape_single_quotes(strip_outer_quotes(value))}'"
+          else strip_outer_quotes(value)
           end
         end
 
@@ -80,10 +81,6 @@ module RuboCop
 
           quote = value[0]
           QUOTE_CHARS.include?(quote) && value.end_with?(quote)
-        end
-
-        def escape_single_quotes(value)
-          value.gsub("'", "\\\\'")
         end
       end
     end

--- a/lib/rubocop/cop/capybara/mixin/css_selector.rb
+++ b/lib/rubocop/cop/capybara/mixin/css_selector.rb
@@ -30,7 +30,7 @@ module RuboCop
         end
 
         # @param selector [String]
-        # @return [Array<String>]
+        # @return [Hash<String, String, Boolean, nil>]
         # @example
         #   classes('#some-id') # => []
         #   classes('.some-cls') # => ['some-cls']
@@ -53,9 +53,9 @@ module RuboCop
         # @return [Array<String>]
         # @example
         #   attributes('a[foo-bar_baz]') # => {"foo-bar_baz=>nil}
-        #   attributes('button[foo][bar=baz]') # => {"foo"=>nil, "bar"=>"'baz'"}
-        #   attributes('table[foo=bar]') # => {"foo"=>"'bar'"}
-        #   attributes('[foo="bar[baz][qux]"]') # => {"foo"=>"'bar[baz][qux]'"}
+        #   attributes('button[foo][bar=baz]') # => {"foo"=>nil, "bar"=>"baz"}
+        #   attributes('table[foo=bar]') # => {"foo"=>"bar"}
+        #   attributes('[foo="bar[baz][qux]"]') # => {"foo"=>"bar[baz][qux]"}
         def attributes(selector)
           CssAttributesParser.new(selector).parse
         end

--- a/lib/rubocop/cop/capybara/specific_finders.rb
+++ b/lib/rubocop/cop/capybara/specific_finders.rb
@@ -68,13 +68,9 @@ module RuboCop
         end
 
         def remove_selector_argument(corrector, node)
-          if node.arguments.size == 1
-            corrector.remove(node.first_argument)
-          else
-            range = range_between(node.first_argument.source_range.begin_pos,
-                                  node.arguments[1].source_range.begin_pos)
-            corrector.remove(range)
-          end
+          range = range_between(node.first_argument.source_range.begin_pos,
+                                node.arguments[1].source_range.begin_pos)
+          corrector.remove(range)
         end
 
         def on_attr(node, sym, arg)
@@ -89,12 +85,12 @@ module RuboCop
           return if CssSelector.attributes(arg).any?
 
           id = CssSelector.id(arg)
-          register_offense(node, sym, "'#{id.delete('\\')}'",
+          register_offense(node, sym, ruby_literal(id.delete('\\')),
                            CssSelector.classes(arg.sub("##{id}", '')))
         end
 
         def on_sym_id(node, sym, id)
-          register_offense(node, sym, "'#{id.delete('\\')}'")
+          register_offense(node, sym, ruby_literal(id.delete('\\')))
         end
 
         def attribute?(arg)
@@ -142,8 +138,9 @@ module RuboCop
         end
 
         def replaced_arguments(arg, id)
-          id = id.delete('\\')
           options = to_options(CssSelector.attributes(arg))
+          id = ruby_literal(id.delete('\\'))
+
           options.empty? ? id : "#{id}, #{options}"
         end
 
@@ -151,8 +148,18 @@ module RuboCop
           attrs.each.filter_map do |key, value|
             next if key == 'id'
 
-            "#{key}: #{value}"
+            "#{key}: #{ruby_literal(value)}"
           end.join(', ')
+        end
+
+        def ruby_literal(value)
+          case value
+          when String
+            "'#{value.gsub(/['\\]/) { |char| "\\#{char}" }}'"
+          when nil then 'nil'
+          else
+            value.to_s
+          end
         end
 
         def offense_range(node)

--- a/spec/rubocop/cop/capybara/mixin/css_attributes_parser_spec.rb
+++ b/spec/rubocop/cop/capybara/mixin/css_attributes_parser_spec.rb
@@ -7,41 +7,41 @@ RSpec.describe RuboCop::Cop::Capybara::CssAttributesParser do
         'foo-bar_baz' => nil
       )
       expect(described_class.new('table[foo=bar]').parse).to eq(
-        'foo' => "'bar'"
+        'foo' => 'bar'
       )
     end
 
     it 'returns attributes hash when attribute value contains equals sign' do
       expect(
         described_class.new('a[href="https://example.test?a=b"]').parse
-      ).to eq('href' => "'https://example.test?a=b'")
+      ).to eq('href' => 'https://example.test?a=b')
     end
 
     it 'returns attributes hash when specify multiple attributes' do
       expect(described_class.new('button[foo][bar=baz]').parse).to eq(
-        'foo' => nil, 'bar' => "'baz'"
+        'foo' => nil, 'bar' => 'baz'
       )
     end
 
     it 'returns attributes hash when specify nested attributes' do
       expect(described_class.new('[foo="bar[baz]"]').parse).to eq(
-        'foo' => "'bar[baz]'"
+        'foo' => 'bar[baz]'
       )
     end
 
     it 'returns attributes hash when attribute value contains quotes' do
       expect(described_class.new(%q([title="Bob's book"])).parse).to eq(
-        'title' => %q('Bob\'s book')
+        'title' => "Bob's book"
       )
       expect(described_class.new(%q([title='Say "hi"'])).parse).to eq(
-        'title' => %q('Say "hi"')
+        'title' => 'Say "hi"'
       )
     end
 
     it 'returns attributes hash when specify nested and include ' \
        'multiple bracket' do
       expect(described_class.new('[foo="bar[baz][qux]"]').parse).to eq(
-        'foo' => "'bar[baz][qux]'"
+        'foo' => 'bar[baz][qux]'
       )
     end
 

--- a/spec/rubocop/cop/capybara/mixin/css_selector_spec.rb
+++ b/spec/rubocop/cop/capybara/mixin/css_selector_spec.rb
@@ -74,41 +74,41 @@ RSpec.describe RuboCop::Cop::Capybara::CssSelector do
         'foo-bar_baz' => nil
       )
       expect(described_class.attributes('table[foo=bar]')).to eq(
-        'foo' => "'bar'"
+        'foo' => 'bar'
       )
     end
 
     it 'returns attributes hash when attribute value contains equals sign' do
       expect(
         described_class.attributes('a[href="https://example.test?a=b"]')
-      ).to eq('href' => "'https://example.test?a=b'")
+      ).to eq('href' => 'https://example.test?a=b')
     end
 
     it 'returns attributes hash when specify multiple attributes' do
       expect(described_class.attributes('button[foo][bar=baz]')).to eq(
-        'foo' => nil, 'bar' => "'baz'"
+        'foo' => nil, 'bar' => 'baz'
       )
     end
 
     it 'returns attributes hash when specify nested attributes' do
       expect(described_class.attributes('[foo="bar[baz]"]')).to eq(
-        'foo' => "'bar[baz]'"
+        'foo' => 'bar[baz]'
       )
     end
 
     it 'returns attributes hash when attribute value contains quotes' do
       expect(described_class.attributes(%q([title="Bob's book"]))).to eq(
-        'title' => %q('Bob\'s book')
+        'title' => "Bob's book"
       )
       expect(described_class.attributes(%q([title='Say "hi"']))).to eq(
-        'title' => %q('Say "hi"')
+        'title' => 'Say "hi"'
       )
     end
 
     it 'returns attributes hash when specify nested and include ' \
        'multiple bracket' do
       expect(described_class.attributes('[foo="bar[baz][qux]"]')).to eq(
-        'foo' => "'bar[baz][qux]'"
+        'foo' => 'bar[baz][qux]'
       )
     end
 

--- a/spec/rubocop/cop/capybara/specific_finders_spec.rb
+++ b/spec/rubocop/cop/capybara/specific_finders_spec.rb
@@ -234,6 +234,21 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificFinders do
     RUBY
   end
 
+  it 'registers an offense when using `find` ' \
+     'with argument is attribute specified id and style' do
+    expect_offense(<<~RUBY)
+      find('[id=some-id][style="font-family:\\'Inter\\'"]')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by_id` over `find`.
+      find('[id=some-id][style="--target:https://example.test?a=b"]')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by_id` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id', style: 'font-family:\\'Inter\\'')
+      find_by_id('some-id', style: '--target:https://example.test?a=b')
+    RUBY
+  end
+
   it 'registers an offense when using `find ' \
      'with argument is attribute specified id surrounded by quotation' do
     expect_offense(<<~RUBY)
@@ -269,6 +284,21 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificFinders do
 
     expect_correction(<<~RUBY)
       find_by_id('some-id', style: 'display:none')
+    RUBY
+  end
+
+  it 'registers an offense when using `find` ' \
+     'with boolean and nil style attributes' do
+    expect_offense(<<~RUBY)
+      find('[id=some-id][style=true]')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by_id` over `find`.
+      find('[id=other-id][style]')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by_id` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id', style: true)
+      find_by_id('other-id', style: nil)
     RUBY
   end
 


### PR DESCRIPTION
Fix CSS attribute parsing so `CssAttributesParser` returns raw attribute values and `Capybara/SpecificFinders` formats Ruby literals during autocorrection.

This keeps parsing separate from Ruby code generation while preserving support for quoted values and values containing `=`.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [-] Added the new cop to `config/default.yml`.
- [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [-] The cop documents examples of good and bad code.
- [-] The tests assert both that bad code is reported and that good code is not reported.
- [-] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [-] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
