### PR TITLE
Fix CSS attribute parser return type docs

### DIFF
--- a/lib/rubocop/cop/capybara/mixin/css_selector.rb
+++ b/lib/rubocop/cop/capybara/mixin/css_selector.rb
@@ -50,7 +50,7 @@ module RuboCop
         end
 
         # @param selector [String]
-        # @return [Array<String>]
+        # @return [Hash<String, String, Boolean, nil>]
         # @example
         #   attributes('a[foo-bar_baz]') # => {"foo-bar_baz=>nil}
         #   attributes('button[foo][bar=baz]') # => {"foo"=>nil, "bar"=>"baz"}


### PR DESCRIPTION
Fix the YARD return type for `CssAttributesParser#parse` and `CssSelector.attributes`.

Both methods return an attributes hash, but their documentation described the return value as an array of strings. This updates the comments to match the actual API and avoid confusion when maintaining the parser.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [x] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [-] Added the new cop to `config/default.yml`.
- [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [-] The cop documents examples of good and bad code.
- [-] The tests assert both that bad code is reported and that good code is not reported.
- [-] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [-] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
