### PR TITLE
Fix CSS selector class parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Edge (Unreleased)
 
 - Fix a false positive for `Capybara/RSpec/HaveSelector` when `DefaultSelector` is unsupported. ([@ydah])
+- Fix an incorrect autocorrect for `Capybara/SpecificFinders` when a selector class is empty or contains an escaped dot. ([@ydah])
 - Fix a false negative for `Capybara/RSpec/NegationMatcherAfterVisit` when using `to_not`. ([@ydah])
 - Fix an incorrect autocorrect for `Capybara/RSpec/PredicateMatcher` when `EnforcedStyle: explicit` and `expect` actual is a complex expression. ([@ydah])
 - Fix a false positive for `Capybara/SpecificActions` when `click` uses arguments or a block. ([@ydah])

--- a/lib/rubocop/cop/capybara/mixin/css_selector.rb
+++ b/lib/rubocop/cop/capybara/mixin/css_selector.rb
@@ -36,8 +36,11 @@ module RuboCop
         #   classes('.some-cls') # => ['some-cls']
         #   classes('#some-id.some-cls') # => ['some-cls']
         #   classes('#some-id.cls1.cls2') # => ['cls1', 'cls2']
+        #   classes('.some-cls\.with-dot') # => ['some-cls.with-dot']
         def classes(selector)
-          selector.scan(/\.([\w-]*)/).flatten
+          selector.scan(/(?<!\\)\.((?:\\.|[\w-])+)/).flatten.map do |class_name|
+            class_name.gsub('\\.', '.')
+          end
         end
 
         # @param selector [String]

--- a/spec/rubocop/cop/capybara/mixin/css_selector_spec.rb
+++ b/spec/rubocop/cop/capybara/mixin/css_selector_spec.rb
@@ -48,6 +48,18 @@ RSpec.describe RuboCop::Cop::Capybara::CssSelector do
         expect(described_class.classes('.cls1.cls2')).to match %w[cls1 cls2]
         expect(described_class.classes('h2.cls1.cls2')).to match %w[cls1 cls2]
       end
+
+      it 'returns empty array when class selector has no name' do
+        expect(described_class.classes('.')).to match []
+        expect(described_class.classes('h1#foo.')).to match []
+      end
+
+      it 'treats escaped dots as part of names' do
+        expect(described_class.classes('#some-id\.id')).to match []
+        expect(
+          described_class.classes('.some-cls\.with-dot')
+        ).to match ['some-cls.with-dot']
+      end
     end
 
     context 'when string whose argument not contains `.`' do

--- a/spec/rubocop/cop/capybara/specific_finders_spec.rb
+++ b/spec/rubocop/cop/capybara/specific_finders_spec.rb
@@ -80,6 +80,28 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificFinders do
     RUBY
   end
 
+  it 'registers an offense when using `find` with id and empty class' do
+    expect_offense(<<~RUBY)
+      find('#some-id.')
+      ^^^^^^^^^^^^^^^^^ Prefer `find_by_id` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id')
+    RUBY
+  end
+
+  it 'registers an offense when using `find` with id and escaped class dot' do
+    expect_offense(<<~RUBY)
+      find('#some-id.some-cls\\.with-dot')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by_id` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id', class: 'some-cls.with-dot')
+    RUBY
+  end
+
   it 'registers an offense when using `find` with id include `\.`' do
     expect_offense(<<~RUBY)
       find('#some-id\\.some-cls')


### PR DESCRIPTION
Fix CSS selector class parsing so empty class selectors are ignored and escaped dots remain part of the class name.

Previously `CssSelector.classes` used a class-name capture that allowed empty matches, so selectors like `#some-id.` could make `Capybara/SpecificFinders` autocorrect to `class: ''`. It also treated escaped dots inside class names as class separators, so `#some-id.some-cls\.with-dot` could become `class: ["some-cls", "with-dot"]`.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [-] Added the new cop to `config/default.yml`.
- [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [-] The cop documents examples of good and bad code.
- [-] The tests assert both that bad code is reported and that good code is not reported.
- [-] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [-] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
