### PR TITLE
Fix CSS selector id parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Edge (Unreleased)
 
+- Fix a false positive for `Capybara/SpecificFinders` when an id selector contains unsupported CSS identifier syntax. ([@ydah])
 - Fix a false negative for `Capybara/RSpec/NegationMatcherAfterVisit` when using `to_not`. ([@ydah])
 - Fix an incorrect autocorrect for `Capybara/RSpec/PredicateMatcher` when `EnforcedStyle: explicit` and `expect` actual is a complex expression. ([@ydah])
 - Fix a false positive for `Capybara/SpecificActions` when `click` uses arguments or a block. ([@ydah])

--- a/lib/rubocop/cop/capybara/mixin/css_selector.rb
+++ b/lib/rubocop/cop/capybara/mixin/css_selector.rb
@@ -8,6 +8,8 @@ module RuboCop
       module CssSelector
         module_function
 
+        ID_PATTERN = /\A#((?:[\w-]|\\[.>,+~])+)(?:\.|\z)/.freeze
+
         # @param selector [String]
         # @return [String]
         # @example
@@ -15,9 +17,7 @@ module RuboCop
         #   id('.some-cls') # => nil
         #   id('#some-id.cls') # => some-id
         def id(selector)
-          return unless id?(selector)
-
-          selector.delete('#').gsub(selector.scan(/[^\\]([>,+~.].*)/).join, '')
+          selector[ID_PATTERN, 1]
         end
 
         # @param selector [String]
@@ -26,7 +26,7 @@ module RuboCop
         #   id?('#some-id') # => true
         #   id?('.some-cls') # => false
         def id?(selector)
-          selector.start_with?('#')
+          !id(selector).nil?
         end
 
         # @param selector [String]

--- a/spec/rubocop/cop/capybara/mixin/css_selector_spec.rb
+++ b/spec/rubocop/cop/capybara/mixin/css_selector_spec.rb
@@ -11,6 +11,20 @@ RSpec.describe RuboCop::Cop::Capybara::CssSelector do
       it 'returns id string when contain `\`' do
         expect(described_class.id('#some-id\.id')).to eq 'some-id\\.id'
       end
+
+      it 'returns nil when selector contains multiple id selectors' do
+        expect(described_class.id('#some-id#other-id')).to be_nil
+        expect(described_class.id('#some-id\#other-id')).to be_nil
+      end
+
+      it 'returns nil when selector contains an unsupported id escape' do
+        expect(described_class.id('#some-id\:field')).to be_nil
+        expect(described_class.id(%q(#some-id\000026other-id))).to be_nil
+      end
+
+      it 'returns nil when selector contains a quote' do
+        expect(described_class.id("#some-id'quote")).to be_nil
+      end
     end
 
     context 'when string whose argument not begins with `#`' do
@@ -26,6 +40,11 @@ RSpec.describe RuboCop::Cop::Capybara::CssSelector do
       it 'returns true' do
         expect(described_class.id?('#some-id')).to be true
         expect(described_class.id?('#some-id.cls')).to be true
+      end
+
+      it 'returns false when selector contains unsupported id syntax' do
+        expect(described_class.id?('#some-id#other-id')).to be false
+        expect(described_class.id?('#some-id\#other-id')).to be false
       end
     end
 

--- a/spec/rubocop/cop/capybara/specific_finders_spec.rb
+++ b/spec/rubocop/cop/capybara/specific_finders_spec.rb
@@ -358,6 +358,16 @@ RSpec.describe RuboCop::Cop::Capybara::SpecificFinders do
   end
 
   it 'does not register an offense when using `find` ' \
+     'with unsupported id selector syntax' do
+    expect_no_offenses(<<~RUBY)
+      find('#some-id#other-id')
+      find('#some-id\\#other-id')
+      find("#some-id'quote")
+      find('#some-id\\000026other-id')
+    RUBY
+  end
+
+  it 'does not register an offense when using `find` ' \
      'with id and attribute' do
     expect_no_offenses(<<~RUBY)
       find('#foo[hidden]')


### PR DESCRIPTION
Fix CSS selector id parsing so `Capybara/SpecificFinders` only autocorrects supported simple id selectors.

Previously `CssSelector.id` removed every `#` in the selector and trimmed matcher suffixes with a broad regexp. That meant unsupported CSS identifier syntax such as multiple id selectors, escaped `#`, quoted values, or Unicode escapes could still be treated as a safe id and produce an incorrect `find_by_id` autocorrection.

This changes id detection to a strict anchored pattern for simple ids and the existing supported escapes, and skips the offense when parsing is unsupported.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [-] Added the new cop to `config/default.yml`.
- [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [-] The cop documents examples of good and bad code.
- [-] The tests assert both that bad code is reported and that good code is not reported.
- [-] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [-] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
