### PR TITLE
Avoid redundant selector lookup in Capybara/SpecificActions

### DIFF
--- a/lib/rubocop/cop/capybara/specific_actions.rb
+++ b/lib/rubocop/cop/capybara/specific_actions.rb
@@ -53,7 +53,7 @@ module RuboCop
         private
 
         def specific_action(selector)
-          SPECIFIC_ACTION[last_selector(selector)]
+          SPECIFIC_ACTION[selector]
         end
 
         def replaceable?(node, arg, action)


### PR DESCRIPTION
Avoid the redundant selector lookup in `Capybara/SpecificActions`.

`on_send` already normalizes the `find` argument with `last_selector(arg)` before calling `specific_action`. This changes `specific_action` to use that normalized selector directly when looking up `SPECIFIC_ACTION`, keeping the behavior the same while making the control flow easier to follow.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [-] Added the new cop to `config/default.yml`.
- [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [-] The cop documents examples of good and bad code.
- [-] The tests assert both that bad code is reported and that good code is not reported.
- [-] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [-] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
