### PR TITLE
Fix HaveSelector with unsupported DefaultSelector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Edge (Unreleased)
 
+- Fix a false positive for `Capybara/RSpec/HaveSelector` when `DefaultSelector` is unsupported. ([@ydah])
 - Fix a false negative for `Capybara/RSpec/NegationMatcherAfterVisit` when using `to_not`. ([@ydah])
 - Fix an incorrect autocorrect for `Capybara/RSpec/PredicateMatcher` when `EnforcedStyle: explicit` and `expect` actual is a complex expression. ([@ydah])
 - Fix a false positive for `Capybara/SpecificActions` when `click` uses arguments or a block. ([@ydah])

--- a/lib/rubocop/cop/capybara/rspec/have_selector.rb
+++ b/lib/rubocop/cop/capybara/rspec/have_selector.rb
@@ -70,17 +70,20 @@ module RuboCop
           end
 
           def on_select_without_type(node)
-            add_offense(node, message: message_untyped) do |corrector|
-              corrector.replace(node.loc.selector, "have_#{default_selector}")
+            return unless (selector = default_selector)
+
+            add_offense(node, message: message_untyped(selector)) do |corrector|
+              corrector.replace(node.loc.selector, "have_#{selector}")
             end
           end
 
-          def message_untyped
-            format(MSG, good: "have_#{default_selector}")
+          def message_untyped(selector)
+            format(MSG, good: "have_#{selector}")
           end
 
           def default_selector
-            cop_config.fetch('DefaultSelector', 'css')
+            selector = cop_config.fetch('DefaultSelector', 'css').to_s.to_sym
+            selector if SELECTORS.include?(selector)
           end
         end
       end

--- a/spec/rubocop/cop/capybara/rspec/have_selector_spec.rb
+++ b/spec/rubocop/cop/capybara/rspec/have_selector_spec.rb
@@ -124,4 +124,14 @@ RSpec.describe RuboCop::Cop::Capybara::RSpec::HaveSelector, :config do
       RUBY
     end
   end
+
+  context 'when DefaultSelector is unsupported' do
+    let(:default_selector) { 'foo' }
+
+    it 'does not register an offense when using `have_selector`' do
+      expect_no_offenses(<<~RUBY)
+        expect(foo).to have_selector('bar')
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fix `Capybara/RSpec/HaveSelector` when `DefaultSelector` is set to an unsupported value.

Previously the cop used the configured `DefaultSelector` directly for untyped `have_selector` calls. If the value was not `css` or `xpath`, it could register an offense and autocorrect to a non-existent matcher such as `have_foo`.

This validates the configured default selector before registering an offense. Unsupported values now leave untyped `have_selector` calls unchanged.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [-] Added the new cop to `config/default.yml`.
- [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [-] The cop documents examples of good and bad code.
- [-] The tests assert both that bad code is reported and that good code is not reported.
- [-] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [-] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
