### PR TITLE
Fix RedundantWithinFind autocorrection with dynamic ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Edge (Unreleased)
 
+- Fix an incorrect autocorrect for `Capybara/RedundantWithinFind` when `find_by_id` uses a dynamic id. ([@ydah])
 - Fix a false positive for `Capybara/RSpec/HaveSelector` when `DefaultSelector` is unsupported. ([@ydah])
 - Fix an incorrect autocorrect for `Capybara/SpecificFinders` when a selector class is empty or contains an escaped dot. ([@ydah])
 - Fix a false negative for `Capybara/RSpec/NegationMatcherAfterVisit` when using `to_not`. ([@ydah])

--- a/lib/rubocop/cop/capybara/redundant_within_find.rb
+++ b/lib/rubocop/cop/capybara/redundant_within_find.rb
@@ -41,8 +41,10 @@ module RuboCop
 
         def on_send(node)
           within_find(node) do |find_node|
+            replacement = replaced(find_node)
+
             add_offense(find_node, message: msg(find_node)) do |corrector|
-              corrector.replace(find_node, replaced(find_node))
+              corrector.replace(find_node, replacement) if replacement
             end
           end
         end
@@ -58,12 +60,9 @@ module RuboCop
             return node.arguments.map(&:source).join(', ')
           end
 
-          if node.first_argument.str_type?
-            build_escaped_selector(node.first_argument, node)
-          else
-            node.arguments.map(&:source).join(', ')
-              .sub(/\A(["'])/, '\1#')
-          end
+          return unless node.first_argument&.str_type?
+
+          build_escaped_selector(node.first_argument, node)
         end
 
         def build_escaped_selector(first_arg, node)

--- a/spec/rubocop/cop/capybara/redundant_within_find_spec.rb
+++ b/spec/rubocop/cop/capybara/redundant_within_find_spec.rb
@@ -105,10 +105,29 @@ RSpec.describe RuboCop::Cop::Capybara::RedundantWithinFind, :config do
       end
     RUBY
 
-    expect_correction(<<~RUBY)
-      within id_variable do
+    expect_no_corrections
+  end
+
+  it 'registers an offense when using `within find_by_id(...)` with ' \
+     'a dynamic id and other argument' do
+    expect_offense(<<~RUBY)
+      within find_by_id(dom_id(user), visible: :all) do
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Redundant `within find_by_id(...)` call detected.
       end
     RUBY
+
+    expect_no_corrections
+  end
+
+  it 'registers an offense when using `within find_by_id(...)` with ' \
+     'an interpolated id' do
+    expect_offense(<<~'RUBY')
+      within find_by_id("user_#{user.id}") do
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Redundant `within find_by_id(...)` call detected.
+      end
+    RUBY
+
+    expect_no_corrections
   end
 
   it 'does not register an offense when using `within` without `find`' do


### PR DESCRIPTION
Fix `Capybara/RedundantWithinFind` when `find_by_id` is called with a dynamic id.

Previously the autocorrection reused non-literal `find_by_id` arguments directly. For example, `within find_by_id(id_variable)` was corrected to `within id_variable`, which can change Capybara selector semantics because `find_by_id` targets an id while `within` receives a selector expression.

This keeps the offense, but only autocorrects `find_by_id` when the id argument is a string literal. Dynamic ids such as `id_variable`, `dom_id(user)`, and interpolated strings are left unchanged.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [-] Added the new cop to `config/default.yml`.
- [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [-] The cop documents examples of good and bad code.
- [-] The tests assert both that bad code is reported and that good code is not reported.
- [-] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [-] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
