### PR TITLE
Pin GitHub Actions to commit hashes

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -9,9 +9,9 @@ jobs:
     name: CodeSpell
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: CodeSpell
-        uses: codespell-project/actions-codespell@master
+        uses: codespell-project/actions-codespell@3abb875e3aa9713e40eed5aea082672a42f7f95c
         with:
           check_filenames: true
           check_hidden: true

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -9,10 +9,10 @@ jobs:
     name: Danger
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74
         with:
           bundler-cache: true
           ruby-version: ruby

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Confirm config and documentation
     steps:
-      - uses: actions/checkout@v7
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74
         with:
           ruby-version: ruby
           bundler-cache: true
@@ -41,8 +41,8 @@ jobs:
           - spec
     name: "Ruby ${{ matrix.ruby }}: ${{ matrix.task }}"
     steps:
-      - uses: actions/checkout@v7
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74
         with:
           ruby-version: "${{ matrix.ruby }}"
           bundler-cache: true
@@ -52,8 +52,8 @@ jobs:
     runs-on: ubuntu-latest
     name: "Test coverage"
     steps:
-      - uses: actions/checkout@v7
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74
         with:
           ruby-version: ruby
           bundler-cache: true
@@ -68,11 +68,11 @@ jobs:
           - spec
     name: "Edge RuboCop: ${{ matrix.task }}"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Use latest RuboCop from `master`
         run: |
           echo "gem 'rubocop', github: 'rubocop/rubocop'" > Gemfile.local
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74
         with:
           ruby-version: ruby
           bundler-cache: true
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     name: RSpec 4
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Use latest RSpec 4 from `main` branch
         run: |
           sed -e '/rspec/d' -i Gemfile
@@ -93,7 +93,7 @@ jobs:
             gem 'rspec-mocks', github: 'rspec/rspec', branch: 'main'
             gem 'rspec-support', github: 'rspec/rspec', branch: 'main'
           EOF
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74
         with:
           ruby-version: ruby
           bundler-cache: true
@@ -103,14 +103,14 @@ jobs:
     runs-on: ubuntu-latest
     name: Prism
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Use prism parser
         run: |
           cat << EOF > Gemfile.local
             gem 'prism'
           EOF
       - name: set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74
         with:
           # Specify the minimum Ruby version 2.7 required for Prism to run.
           ruby-version: 2.7

--- a/.github/workflows/mdformat.yml
+++ b/.github/workflows/mdformat.yml
@@ -9,9 +9,9 @@ jobs:
     name: Mdformat
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Mdformat
-        uses: ydah/mdformat-action@main
+        uses: ydah/mdformat-action@2549a9e71ea0102aa1f48876b344caf6bccca0e0
         with:
           number: true
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,13 +13,13 @@ jobs:
       id-token: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74
         with:
           bundler-cache: true
           ruby-version: ruby
-      - uses: rubygems/release-gem@v1
+      - uses: rubygems/release-gem@052cc82692552de3ef2b81fd670e41d13cba8092
       - name: Create a GitHub release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -9,9 +9,9 @@ jobs:
     name: Yamllint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Yamllint
-        uses: karancode/yamllint-github-action@master
+        uses: karancode/yamllint-github-action@4052d365f09b8d34eb552c363d1141fd60e2aeb2
         with:
           yamllint_strict: true
           yamllint_format: parsable


### PR DESCRIPTION
Pin GitHub Actions workflow dependencies to full commit hashes.

This replaces tag and branch references in workflow `uses:` entries with the commit SHA currently resolved from each upstream action. This makes CI and publish workflows less dependent on mutable refs such as `v1`, `master`, and `main`.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [-] Added the new cop to `config/default.yml`.
- [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [-] The cop documents examples of good and bad code.
- [-] The tests assert both that bad code is reported and that good code is not reported.
- [-] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [-] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
