### PR TITLE
Add issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,48 @@
+---
+name: Bug Report
+about: Report an issue with RuboCop Capybara you've discovered.
+---
+
+*Be clear, concise and precise in your description of the problem.
+Open an issue with a descriptive title and a summary in grammatically correct,
+complete sentences.*
+
+*Use the template below when reporting bugs. Please, make sure that
+you're running the latest stable RuboCop Capybara and that the problem you're reporting
+hasn't been reported (and potentially fixed) already.*
+
+*Before filing the ticket you should replace all text above the horizontal
+rule with your own words.*
+
+*In the case of false positive or false negative, please add the
+corresponding cop name.*
+
+______________________________________________________________________
+
+## Steps to reproduce the problem
+
+This is extremely important! Providing us with a reliable way to reproduce
+a problem will expedite its solution.
+
+## Expected behavior
+
+Describe here how you expected RuboCop Capybara to behave in this particular situation.
+
+## Actual behavior
+
+Describe here what actually happened.
+Please use `rubocop --debug` when pasting rubocop output as it contains additional information.
+
+## RuboCop Capybara version
+
+Include the output of `rubocop -V` or `bundle exec rubocop -V` if using Bundler.
+If you see extension cop versions (e.g. `rubocop-performance`, `rubocop-rake`, and others)
+output by `rubocop -V`, include them as well. Here's an example:
+
+```shell
+$ [bundle exec] rubocop -V
+1.67.0 (using Parser 3.3.5.0, rubocop-ast 1.32.3, analyzing as Ruby 2.7, running on ruby 3.4.0) [arm64-darwin23]
+  - rubocop-performance 1.22.1
+  - rubocop-rake 0.6.0
+  - rubocop-capybara 3.0.0
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature Request
+about: Suggest new RuboCop Capybara features or improvements to existing features.
+---
+
+## Is your feature request related to a problem? Please describe.
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+## Describe the solution you'd like
+
+A clear and concise description of what you want to happen.
+
+## Describe alternatives you've considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Additional context
+
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Add GitHub issue templates for bug reports and feature requests.

The bug report template follows the current RuboCop RSpec layout, including an early reproduction section, and uses RuboCop Capybara-specific wording and version output examples.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests. Not applicable; this only adds issue templates.
- [x] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes. Not applicable; no code behavior changed.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
