### PR TITLE
Fix `Capybara/FindAllFirst` false positive on keyword-only `all(...)` calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Edge (Unreleased)
 
+- Fix a false positive for `Capybara/FindAllFirst` when `all` is called with keyword arguments only (e.g. a non-Capybara collection method like `all(include_inactive: true).first`). ([@professor])
 - Fix an incorrect autocorrect for `Capybara/RedundantWithinFind` when `find_by_id` uses a dynamic id. ([@ydah])
 - Fix a false positive for `Capybara/RSpec/HaveSelector` when `DefaultSelector` is unsupported. ([@ydah])
 - Fix an incorrect autocorrect for `Capybara/SpecificFinders` when a selector class is empty or contains an escaped dot. ([@ydah])
@@ -126,6 +127,7 @@
 [@onumis]: https://github.com/onumis
 [@oskarsezerins]: https://github.com/OskarsEzerins
 [@pirj]: https://github.com/pirj
+[@professor]: https://github.com/professor
 [@rspeicher]: https://github.com/rspeicher
 [@timrogers]: https://github.com/timrogers
 [@twalpole]: https://github.com/twalpole

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Edge (Unreleased)
 
+- Fix a false positive for `Capybara/FindAllFirst` when `all` is called with keyword arguments that are not Capybara finder options (e.g. a non-Capybara collection method like `all(include_inactive: true).first`), while still flagging valid keyword-only Capybara calls like `all(text: 'Home').first`. ([@professor])
 - Fix an incorrect autocorrect for `Capybara/RedundantWithinFind` when `find_by_id` uses a dynamic id. ([@ydah])
 - Fix a false positive for `Capybara/RSpec/HaveSelector` when `DefaultSelector` is unsupported. ([@ydah])
 - Fix an incorrect autocorrect for `Capybara/SpecificFinders` when a selector class is empty or contains an escaped dot. ([@ydah])
@@ -126,6 +127,7 @@
 [@onumis]: https://github.com/onumis
 [@oskarsezerins]: https://github.com/OskarsEzerins
 [@pirj]: https://github.com/pirj
+[@professor]: https://github.com/professor
 [@rspeicher]: https://github.com/rspeicher
 [@timrogers]: https://github.com/timrogers
 [@twalpole]: https://github.com/twalpole

--- a/lib/rubocop/cop/capybara/find_all_first.rb
+++ b/lib/rubocop/cop/capybara/find_all_first.rb
@@ -30,6 +30,21 @@ module RuboCop
         MSG = 'Use `first(%<selector>s)`.'
         RESTRICT_ON_SEND = %i[all find].freeze
 
+        # Global query options accepted by Capybara's `all`/`first`. A
+        # keyword-only `all(...)` whose keys are all valid Capybara options
+        # (e.g. `all(text: 'Home')`) is a real Capybara call. One with an
+        # unknown key (e.g. `all(include_inactive: true)`) is a non-Capybara
+        # collection method whose autocorrect to `first(...)` would break.
+        CAPYBARA_FINDER_OPTIONS = Set.new(
+          %i[
+            above below left_of right_of near
+            count minimum maximum between
+            text exact_text normalize_ws
+            visible obscured exact match wait
+            id class style focused
+          ]
+        ).freeze
+
         # @!method find_all_first?(node)
         def_node_matcher :find_all_first?, <<~PATTERN
           {
@@ -54,7 +69,12 @@ module RuboCop
           return unless (parent = node.parent)
           return unless find_all_first?(parent)
           return if part_of_logical_operator?(parent)
+          return if keyword_only_all?(node)
 
+          register_all_first_offense(node, parent)
+        end
+
+        def register_all_first_offense(node, parent)
           range = range_between(node.loc.selector.begin_pos,
                                 parent.loc.selector.end_pos)
           selector = node.arguments.map(&:source).join(', ')
@@ -85,6 +105,28 @@ module RuboCop
 
         def part_of_logical_operator?(node)
           node.ancestors.any?(&:operator_keyword?)
+        end
+
+        # Skips keyword-only `all(...)` calls that are not Capybara finders.
+        # Capybara's `all` takes a positional selector, but also accepts a
+        # selectorless keyword-only form (e.g. `all(text: 'Home')`). Those are
+        # still valid Capybara calls, so only skip when a keyword is not a
+        # known Capybara option (or the keys can't be determined, e.g. a double
+        # splat). `find_all_first?` guarantees `node` is an `all` send with an
+        # argument.
+        def keyword_only_all?(node)
+          first_argument = node.first_argument
+          return false unless first_argument.hash_type?
+
+          !capybara_finder_options_only?(first_argument)
+        end
+
+        def capybara_finder_options_only?(hash_node)
+          hash_node.pairs.size == hash_node.children.size &&
+            hash_node.pairs.all? do |pair|
+              pair.key.sym_type? &&
+                CAPYBARA_FINDER_OPTIONS.include?(pair.key.value)
+            end
         end
       end
     end

--- a/lib/rubocop/cop/capybara/find_all_first.rb
+++ b/lib/rubocop/cop/capybara/find_all_first.rb
@@ -54,7 +54,12 @@ module RuboCop
           return unless (parent = node.parent)
           return unless find_all_first?(parent)
           return if part_of_logical_operator?(parent)
+          return if keyword_only_all?(node)
 
+          register_all_first_offense(node, parent)
+        end
+
+        def register_all_first_offense(node, parent)
           range = range_between(node.loc.selector.begin_pos,
                                 parent.loc.selector.end_pos)
           selector = node.arguments.map(&:source).join(', ')
@@ -85,6 +90,14 @@ module RuboCop
 
         def part_of_logical_operator?(node)
           node.ancestors.any?(&:operator_keyword?)
+        end
+
+        # Capybara's `all` takes a positional selector as its first argument.
+        # A keyword-only `all(...)` (e.g. `all(include_inactive: true)`) is a
+        # non-Capybara collection method, so `first(...)` would not apply.
+        # `find_all_first?` guarantees `node` is an `all` send with an argument.
+        def keyword_only_all?(node)
+          node.first_argument.hash_type?
         end
       end
     end

--- a/spec/rubocop/cop/capybara/find_all_first_spec.rb
+++ b/spec/rubocop/cop/capybara/find_all_first_spec.rb
@@ -147,6 +147,60 @@ RSpec.describe RuboCop::Cop::Capybara::FindAllFirst, :config do
     RUBY
   end
 
+  it 'registers an offense for keyword-only `all` with a Capybara ' \
+     'finder option' do
+    expect_offense(<<~RUBY)
+      all(text: 'Home').first
+      ^^^^^^^^^^^^^^^^^^^^^^^ Use `first(text: 'Home')`.
+      all(text: 'Home')[0]
+      ^^^^^^^^^^^^^^^^^^^^ Use `first(text: 'Home')`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      first(text: 'Home')
+      first(text: 'Home')
+    RUBY
+  end
+
+  it 'registers an offense for keyword-only `all` with a Capybara ' \
+     'finder option and receiver' do
+    expect_offense(<<~RUBY)
+      page.all(text: 'Home').first
+           ^^^^^^^^^^^^^^^^^^^^^^^ Use `first(text: 'Home')`.
+      page.all(text: 'Home')[0]
+           ^^^^^^^^^^^^^^^^^^^^ Use `first(text: 'Home')`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      page.first(text: 'Home')
+      page.first(text: 'Home')
+    RUBY
+  end
+
+  it 'does not register an offense when `all` receives non-Capybara ' \
+     'keyword arguments only' do
+    expect_no_offenses(<<~RUBY)
+      jobs.all(include_inactive: true).first
+      jobs.all(include_inactive: true)[0]
+    RUBY
+  end
+
+  it 'does not register an offense when `all` mixes Capybara and ' \
+     'non-Capybara keyword arguments' do
+    expect_no_offenses(<<~RUBY)
+      jobs.all(text: 'Home', include_inactive: true).first
+      jobs.all(text: 'Home', include_inactive: true)[0]
+    RUBY
+  end
+
+  it 'does not register an offense when keyword-only `all` uses a ' \
+     'double splat' do
+    expect_no_offenses(<<~RUBY)
+      jobs.all(**options).first
+      jobs.all(**options)[0]
+    RUBY
+  end
+
   context 'when using logical operators' do
     it 'does not register an offense when using `all` with ' \
        '`[0]` and `||` operator' do

--- a/spec/rubocop/cop/capybara/find_all_first_spec.rb
+++ b/spec/rubocop/cop/capybara/find_all_first_spec.rb
@@ -147,6 +147,14 @@ RSpec.describe RuboCop::Cop::Capybara::FindAllFirst, :config do
     RUBY
   end
 
+  it 'does not register an offense when `all` receives keyword ' \
+     'arguments only' do
+    expect_no_offenses(<<~RUBY)
+      jobs.all(include_inactive: true).first
+      jobs.all(include_inactive: true)[0]
+    RUBY
+  end
+
   context 'when using logical operators' do
     it 'does not register an offense when using `all` with ' \
        '`[0]` and `||` operator' do


### PR DESCRIPTION
# Human notes
This PR is generated by claude. While trying to fix a Capybara/FindAllFirst in a very large code base, claude detected that it was a false positive. I'm not an AST expert, so I appreciate any feedback on the PR. 

I tested this PR with our repo, and the false positive is fixed.

# Description
`Capybara/FindAllFirst` matches `<receiver>.all(<arg>).first` (and `.all(<arg>)[0]`) for **any** receiver — its node pattern uses a wildcard receiver with no Capybara-awareness. It therefore flags non-Capybara code that happens to expose an `all` collection method invoked with keyword arguments, for example:

```ruby
# a domain object, not a Capybara node/session
People::Compensate::Jobs.new(company_member).all(include_inactive: true).first
```

Here `all` returns a plain collection and `.first` is `Enumerable#first`. The object has no `first` method taking those keyword arguments, so the cop's suggested autocorrect — `first(include_inactive: true)` — would call a method that does not exist and break the code.

Capybara's own `all`/`find` always take a **positional selector** as their first argument, so a keyword-only `all(...)` is never a Capybara call. This PR skips the offense when `all`'s first argument is a keyword hash. It errs safe: in the (degenerate, selectorless) ambiguous case it declines to flag rather than emit a broken autocorrect. Real Capybara usage — `all('a').first`, `all(:css, '.btn').first`, `all('a', text: 'b').first` — is unaffected.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
