### PR TITLE
Fix false positives and incorrect autocorrections for `Capybara/FindAllFirst` when `find` or `all` uses `match: :first`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Edge (Unreleased)
 
+- Fix false positives and incorrect autocorrections for `Capybara/FindAllFirst` when `find` or `all` uses `match: :first`. ([@ydah])
 - Fix an incorrect autocorrect for `Capybara/RedundantWithinFind` when `find_by_id` uses a dynamic id. ([@ydah])
 - Fix a false positive for `Capybara/RSpec/HaveSelector` when `DefaultSelector` is unsupported. ([@ydah])
 - Fix an incorrect autocorrect for `Capybara/SpecificFinders` when a selector class is empty or contains an escaped dot. ([@ydah])

--- a/docs/modules/ROOT/pages/cops_capybara.adoc
+++ b/docs/modules/ROOT/pages/cops_capybara.adoc
@@ -107,8 +107,6 @@ being a collection (e.g. calling `.each` on the result).
 # bad
 all('a').first
 all('a')[0]
-find('a', match: :first)
-all('a', match: :first)
 
 # good
 first('a')

--- a/lib/rubocop/cop/capybara/find_all_first.rb
+++ b/lib/rubocop/cop/capybara/find_all_first.rb
@@ -17,8 +17,6 @@ module RuboCop
       #   # bad
       #   all('a').first
       #   all('a')[0]
-      #   find('a', match: :first)
-      #   all('a', match: :first)
       #
       #   # good
       #   first('a')
@@ -28,7 +26,7 @@ module RuboCop
         include RangeHelp
 
         MSG = 'Use `first(%<selector>s)`.'
-        RESTRICT_ON_SEND = %i[all find].freeze
+        RESTRICT_ON_SEND = %i[all].freeze
 
         # @!method find_all_first?(node)
         def_node_matcher :find_all_first?, <<~PATTERN
@@ -38,19 +36,7 @@ module RuboCop
           }
         PATTERN
 
-        # @!method include_match_first?(node)
-        def_node_matcher :include_match_first?, <<~PATTERN
-          (send _ {:find :all} _ $(hash <(pair (sym :match) (sym :first)) ...>))
-        PATTERN
-
         def on_send(node)
-          on_all_first(node)
-          on_match_first(node)
-        end
-
-        private
-
-        def on_all_first(node)
           return unless (parent = node.parent)
           return unless find_all_first?(parent)
           return if part_of_logical_operator?(parent)
@@ -64,24 +50,7 @@ module RuboCop
           end
         end
 
-        def on_match_first(node)
-          include_match_first?(node) do |hash|
-            selector = ([node.first_argument.source] + replaced_hash(hash))
-              .join(', ')
-            range = range_between(node.loc.selector.begin_pos,
-                                  node.source_range.end_pos)
-            add_offense(range,
-                        message: format(MSG, selector: selector)) do |corrector|
-              corrector.replace(range, "first(#{selector})")
-            end
-          end
-        end
-
-        def replaced_hash(hash)
-          hash.child_nodes.flat_map(&:source).reject do |arg|
-            arg == 'match: :first'
-          end
-        end
+        private
 
         def part_of_logical_operator?(node)
           node.ancestors.any?(&:operator_keyword?)

--- a/spec/rubocop/cop/capybara/find_all_first_spec.rb
+++ b/spec/rubocop/cop/capybara/find_all_first_spec.rb
@@ -23,59 +23,21 @@ RSpec.describe RuboCop::Cop::Capybara::FindAllFirst, :config do
     RUBY
   end
 
-  it 'registers an offense when using `find` with `match: :first`' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense when using `find` with `match: :first`' do
+    expect_no_offenses(<<~RUBY)
       find('a', match: :first)
-      ^^^^^^^^^^^^^^^^^^^^^^^^ Use `first('a')`.
       find('a', text: 'b', match: :first)
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `first('a', text: 'b')`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      first('a')
-      first('a', text: 'b')
-    RUBY
-  end
-
-  it 'registers an offense for `find(..., match: :first)` with receiver' do
-    expect_offense(<<~RUBY)
       page.find('a', match: :first)
-           ^^^^^^^^^^^^^^^^^^^^^^^^ Use `first('a')`.
       page.find('a', text: 'b', match: :first)
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `first('a', text: 'b')`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      page.first('a')
-      page.first('a', text: 'b')
     RUBY
   end
 
-  it 'registers an offense when using `all` with `match: :first`' do
-    expect_offense(<<~RUBY)
+  it 'does not register an offense when using `all` with `match: :first`' do
+    expect_no_offenses(<<~RUBY)
       all('a', match: :first)
-      ^^^^^^^^^^^^^^^^^^^^^^^ Use `first('a')`.
       all('a', text: 'b', match: :first)
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `first('a', text: 'b')`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      first('a')
-      first('a', text: 'b')
-    RUBY
-  end
-
-  it 'registers an offense for `all(..., match: :first)` with receiver' do
-    expect_offense(<<~RUBY)
       page.all('a', match: :first)
-           ^^^^^^^^^^^^^^^^^^^^^^^ Use `first('a')`.
       page.all('a', text: 'b', match: :first)
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `first('a', text: 'b')`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      page.first('a')
-      page.first('a', text: 'b')
     RUBY
   end
 


### PR DESCRIPTION
Fixes: https://github.com/rubocop/rubocop-capybara/issues/202

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
