### PR TITLE
Add new `Capybara/IneffectiveQueryOption` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Edge (Unreleased)
 
 - Speed up loading rubocop-capybara by lazily loading only the cops needed for a run. This requires RuboCop 1.89.0+. ([@koic])
+- Add new `Capybara/IneffectiveQueryOption` cop. ([@ydah])
+- Fix false positives and incorrect autocorrections for `Capybara/FindAllFirst` when `find` or `all` uses `match: :first`. ([@ydah])
 - Fix an incorrect autocorrect for `Capybara/RedundantWithinFind` when `find_by_id` uses a dynamic id. ([@ydah])
 - Fix a false positive for `Capybara/RSpec/HaveSelector` when `DefaultSelector` is unsupported. ([@ydah])
 - Fix an incorrect autocorrect for `Capybara/SpecificFinders` when a selector class is empty or contains an escaped dot. ([@ydah])

--- a/config/default.yml
+++ b/config/default.yml
@@ -30,6 +30,13 @@ Capybara/FindAllFirst:
   VersionChanged: '3.0'
   Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/FindAllFirst
 
+Capybara/IneffectiveQueryOption:
+  Description: Checks for query options that have no effect in Capybara.
+  Enabled: pending
+  DefaultSelector: css
+  VersionAdded: "<<next>>"
+  Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/IneffectiveQueryOption
+
 Capybara/RedundantWithinFind:
   Description: Checks for redundant `within find(...)` calls.
   Enabled: true

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -5,6 +5,7 @@
 * xref:cops_capybara.adoc#capybaraambiguousclick[Capybara/AmbiguousClick]
 * xref:cops_capybara.adoc#capybaraassertstyle[Capybara/AssertStyle]
 * xref:cops_capybara.adoc#capybarafindallfirst[Capybara/FindAllFirst]
+* xref:cops_capybara.adoc#capybaraineffectivequeryoption[Capybara/IneffectiveQueryOption]
 * xref:cops_capybara.adoc#capybararedundantwithinfind[Capybara/RedundantWithinFind]
 * xref:cops_capybara.adoc#capybaraspecificactions[Capybara/SpecificActions]
 * xref:cops_capybara.adoc#capybaraspecificfinders[Capybara/SpecificFinders]

--- a/docs/modules/ROOT/pages/cops_capybara.adoc
+++ b/docs/modules/ROOT/pages/cops_capybara.adoc
@@ -119,6 +119,76 @@ first('a')
 
 * https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/FindAllFirst
 
+[#capybaraineffectivequeryoption]
+== Capybara/IneffectiveQueryOption
+
+|===
+| Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
+
+| Pending
+| Yes
+| Always
+| <<next>>
+| -
+|===
+
+Checks for query options that have no effect in Capybara.
+
+Count options passed to singular finders are not autocorrected because
+removing them may conceal the author's intent.
+
+This cop targets Capybara's built-in selectors. Set `DefaultSelector`
+to match `Capybara.default_selector`, or to `null` if it varies at
+runtime. Queries using custom or unknown selectors are skipped.
+
+[#examples-capybaraineffectivequeryoption]
+=== Examples
+
+[source,ruby]
+----
+# bad
+find('.row', count: 3)
+find(:css, '.item', exact: true)
+find('.item', text: /foo/, exact_text: true)
+all(:css, '.item', match: :first)
+expect(page).to have_css('.item', count: 3, minimum: 1)
+
+# good
+all('.row', count: 3)
+find(:css, '.item')
+find('.item', text: /foo/)
+all(:css, '.item')
+expect(page).to have_css('.item', count: 3)
+----
+
+[#defaultselector_-custom-capybaraineffectivequeryoption]
+==== DefaultSelector: custom
+
+[source,ruby]
+----
+# bad
+find(:css, '.item', text: /foo/, exact_text: true)
+
+# good
+find('.item', text: /foo/, exact_text: true)
+----
+
+[#configurable-attributes-capybaraineffectivequeryoption]
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| DefaultSelector
+| `css`
+| String
+|===
+
+[#references-capybaraineffectivequeryoption]
+=== References
+
+* https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/IneffectiveQueryOption
+
 [#capybararedundantwithinfind]
 == Capybara/RedundantWithinFind
 

--- a/lib/rubocop-capybara.rb
+++ b/lib/rubocop-capybara.rb
@@ -8,6 +8,7 @@ require_relative 'rubocop/capybara/version'
 require_relative 'rubocop/cop/capybara/mixin/capybara_help'
 require_relative 'rubocop/cop/capybara/mixin/css_attributes_parser'
 require_relative 'rubocop/cop/capybara/mixin/css_selector'
+require_relative 'rubocop/cop/capybara/mixin/query_methods'
 
 require_relative 'rubocop/cop/capybara'
 

--- a/lib/rubocop/cop/capybara.rb
+++ b/lib/rubocop/cop/capybara.rb
@@ -12,6 +12,7 @@ module RuboCop
       register_cop :AmbiguousClick, "#{__dir__}/capybara/ambiguous_click"
       register_cop :AssertStyle, "#{__dir__}/capybara/assert_style"
       register_cop :FindAllFirst, "#{__dir__}/capybara/find_all_first"
+      register_cop :IneffectiveQueryOption, "#{__dir__}/capybara/ineffective_query_option"
       register_cop :RedundantWithinFind, "#{__dir__}/capybara/redundant_within_find"
       register_cop :SpecificActions, "#{__dir__}/capybara/specific_actions"
       register_cop :SpecificFinders, "#{__dir__}/capybara/specific_finders"

--- a/lib/rubocop/cop/capybara/ineffective_query_option.rb
+++ b/lib/rubocop/cop/capybara/ineffective_query_option.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Capybara
+      # Checks for query options that have no effect in Capybara.
+      #
+      # Count options passed to singular finders are not autocorrected because
+      # removing them may conceal the author's intent.
+      #
+      # This cop targets Capybara's built-in selectors. Set `DefaultSelector`
+      # to match `Capybara.default_selector`, or to `null` if it varies at
+      # runtime. Queries using custom or unknown selectors are skipped.
+      #
+      # @example
+      #   # bad
+      #   find('.row', count: 3)
+      #   find(:css, '.item', exact: true)
+      #   find('.item', text: /foo/, exact_text: true)
+      #   all(:css, '.item', match: :first)
+      #   expect(page).to have_css('.item', count: 3, minimum: 1)
+      #
+      #   # good
+      #   all('.row', count: 3)
+      #   find(:css, '.item')
+      #   find('.item', text: /foo/)
+      #   all(:css, '.item')
+      #   expect(page).to have_css('.item', count: 3)
+      #
+      # @example DefaultSelector: custom
+      #   # bad
+      #   find(:css, '.item', text: /foo/, exact_text: true)
+      #
+      #   # good
+      #   find('.item', text: /foo/, exact_text: true)
+      #
+      class IneffectiveQueryOption < RuboCop::Cop::Base # rubocop:disable Metrics/ClassLength
+        extend AutoCorrector
+        include RangeHelp
+        include CapybaraHelp
+
+        RESTRICT_ON_SEND = QueryMethods.names(
+          :finder, :collection, :selector, :match, :text
+        ).freeze
+        COUNT_OPTIONS = %i[count minimum maximum between].freeze
+        MATCH_STRATEGIES = %i[first smart prefer_exact one].freeze
+
+        FIND_COUNT_MSG =
+          '`%<option>s` has no effect when passed to `%<method>s`.'
+        EXACT_MSG = '`exact` has no effect on CSS queries.'
+        EXACT_TEXT_MSG =
+          '`exact_text` has no effect when `text` is a regexp.'
+        MATCH_MSG =
+          '`match` has no effect when passed to `%<method>s`.'
+        SHADOWED_COUNT_MSG =
+          '`%<option>s` has no effect when `count` is specified.'
+
+        # @!method query_options(node)
+        def_node_matcher :query_options, <<~PATTERN
+          (call #capybara_receiver? _ <$(hash ...) ...>)
+        PATTERN
+
+        # @!method custom_filters?(node)
+        def_node_matcher :custom_filters?, <<~PATTERN
+          (hash <{(pair (sym {:filter_set :session_options}) _) (pair !sym _) kwsplat} ...>)
+        PATTERN
+
+        # @!method removable_value?(node)
+        def_node_matcher :removable_value?, <<~PATTERN
+          {basic_literal? (range {int nil?} {int nil?})}
+        PATTERN
+
+        def on_send(node)
+          return unless (options = query_options(node))
+          return if options.braces?
+          return if custom_filters?(options)
+
+          issues = options.pairs.filter_map do |pair|
+            issue_for(node, options, pair)
+          end
+          return if issues.empty?
+
+          register_issues(node, options, issues)
+        end
+        alias on_csend on_send
+
+        private
+
+        def register_issues(node, options, issues)
+          correction_pair = issues.find do |pair, _, correctable|
+            correctable && removable?(options, pair) && !comments_in?(node)
+          end
+          issues.each do |pair, message, _|
+            add_offense(pair, message: message) do |corrector|
+              next unless pair == correction_pair&.first
+
+              remove_option(corrector, node, options, pair)
+            end
+          end
+        end
+
+        def issue_for(node, options, pair)
+          option = pair.key.value
+          issue = find_count_issue(node, option) ||
+            exact_issue(node, option) ||
+            exact_text_issue(node, option, pair, options) ||
+            match_issue(node, option, pair) ||
+            shadowed_count_issue(node, option, options)
+
+          [pair, *issue] if issue
+        end
+
+        def find_count_issue(node, option)
+          return unless QueryMethods.type(node.method_name) == :finder
+          return unless COUNT_OPTIONS.include?(option)
+          return if custom_selector?(node)
+
+          [
+            format(FIND_COUNT_MSG,
+                   option: option,
+                   method: node.method_name),
+            false
+          ]
+        end
+
+        def shadowed_count_issue(node, option, options)
+          return if QueryMethods.type(node.method_name) == :match
+          return unless count_query_with_known_selector?(node)
+          return unless shadowed_count?(option, options)
+
+          [format(SHADOWED_COUNT_MSG, option: option), true]
+        end
+
+        def exact_issue(node, option)
+          [EXACT_MSG, true] if option == :exact && css_query?(node)
+        end
+
+        def exact_text_issue(node, option, pair, options)
+          return unless option == :exact_text
+          return unless ineffective_exact_text?(node, pair, options)
+
+          [EXACT_TEXT_MSG, true]
+        end
+
+        def match_issue(node, option, pair)
+          return unless option == :match && ineffective_match?(node, pair)
+
+          [format(MATCH_MSG, method: node.method_name), true]
+        end
+
+        def css_query?(node)
+          selector = QueryMethods.selector(node.method_name)
+          selector == :css ||
+            (selector == :selector && explicit_selector(node) == :css)
+        end
+
+        def explicit_selector(node)
+          argument = node.first_argument
+          argument.value if argument&.sym_type?
+        end
+
+        def ineffective_exact_text?(node, pair, options)
+          exact_text_supported_call?(node) &&
+            effective_option_pair(options, :exact_text) == pair &&
+            pair.value.type?(:boolean) &&
+            effective_option_pair(options, :text)&.value&.regexp_type?
+        end
+
+        def exact_text_supported_call?(node)
+          QueryMethods.type(node.method_name) != :text &&
+            !custom_selector?(node)
+        end
+
+        def ineffective_match?(node, pair)
+          QueryMethods.type(node.method_name) == :collection &&
+            QueryMethods.built_in_selector?(explicit_selector(node)) &&
+            pair.value.sym_type? &&
+            MATCH_STRATEGIES.include?(pair.value.value)
+        end
+
+        def shadowed_count?(option, options)
+          option != :count && COUNT_OPTIONS.include?(option) &&
+            count_specified?(options)
+        end
+
+        def count_query_with_known_selector?(node)
+          selector = QueryMethods.selector(node.method_name)
+          return true unless selector == :selector
+
+          QueryMethods.built_in_selector?(explicit_selector(node))
+        end
+
+        def custom_selector?(node)
+          QueryMethods.selector(node.method_name) == :selector &&
+            !QueryMethods.built_in_selector?(query_selector(node))
+        end
+
+        def query_selector(node)
+          selector = explicit_selector(node)
+          return selector if selector
+
+          positional = node.arguments.reject do |arg|
+            arg.type?(:hash, :block_pass)
+          end
+          return if positional.length > 1
+
+          cop_config.fetch('DefaultSelector', 'css').to_s.to_sym
+        end
+
+        def count_specified?(options)
+          effective_option_pair(options, :count)&.value&.truthy_literal?
+        end
+
+        def effective_option_pair(options, name)
+          options.pairs.reverse_each.find { |pair| pair.key.value == name }
+        end
+
+        def comments_in?(node)
+          processed_source.comments.any? do |comment|
+            comment.loc.line.between?(node.first_line, node.last_line)
+          end
+        end
+
+        def removable?(options, pair)
+          return false unless removable_value?(pair.value)
+          return false if pair.value.str_type? && pair.value.heredoc?
+
+          options.pairs.one? { |other| other.key == pair.key }
+        end
+
+        def remove_option(corrector, node, options, pair)
+          first = node.first_argument == options &&
+            options.children.first == pair
+          side = first ? :right : :left
+          range = range_with_surrounding_space(pair.source_range, side: side)
+          range = range_with_surrounding_comma(range, side)
+          corrector.remove(range_with_surrounding_space(range, side: side))
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/capybara/mixin/capybara_help.rb
+++ b/lib/rubocop/cop/capybara/mixin/capybara_help.rb
@@ -6,6 +6,8 @@ module RuboCop
       # Help methods for capybara.
       # @api private
       module CapybaraHelp
+        extend RuboCop::AST::NodePattern::Macros
+
         CAPYBARA_MATCHERS = %w[
           selector css xpath text title current_path link button
           field checked_field unchecked_field select table
@@ -47,6 +49,20 @@ module RuboCop
         ].freeze
 
         module_function
+
+        # Recognize the Capybara DSL and finder chains, not arbitrary objects
+        # with methods such as Enumerable#find or ActiveRecord#first.
+        # @!method capybara_receiver?(node)
+        def_node_matcher :capybara_receiver?, <<~PATTERN
+          {nil? self
+           (call {nil? self} :page)
+           (call (const {nil? cbase} :Capybara) :current_session)
+           (call #capybara_receiver?
+             {:ancestor :find :find_button :find_by_id :find_field :find_link :first :sibling} ...)
+           (any_block #capybara_receiver? ...)
+           (begin #capybara_receiver?)}
+        PATTERN
+        module_function :capybara_receiver?
 
         # @param node [RuboCop::AST::SendNode]
         # @param locator [String]

--- a/lib/rubocop/cop/capybara/mixin/query_methods.rb
+++ b/lib/rubocop/cop/capybara/mixin/query_methods.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Capybara
+      # Classification of Capybara's public query methods.
+      # @api private
+      module QueryMethods
+        BUILT_IN_SELECTORS = %i[
+          button checkbox css datalist_input datalist_option element field
+          fieldset file_field fillable_field frame id label link link_or_button
+          option radio_button select table table_row xpath
+        ].freeze
+
+        # Each entry contains the query type and its selector. `:selector`
+        # means the selector is an argument; nil means it is not applicable.
+        METHODS = begin
+          methods = {
+            find: %i[finder selector],
+            ancestor: %i[finder selector],
+            sibling: %i[finder selector],
+            find_button: %i[finder button],
+            find_by_id: %i[finder id],
+            find_field: %i[finder field],
+            find_link: %i[finder link]
+          }
+          %i[all find_all first].each do |name|
+            methods[name] = %i[collection selector]
+          end
+
+          %w[
+            ancestor button checked_field css element field link select
+            selector sibling table unchecked_field xpath
+          ].each do |selector|
+            kind = case selector
+                   when 'ancestor', 'sibling' then :selector
+                   when 'checked_field', 'unchecked_field' then :field
+                   else selector.to_sym
+                   end
+            prefixes = %w[assert assert_no refute has has_no have have_no]
+            prefixes += %w[must_have wont_have] unless selector == 'element'
+            prefixes.each do |prefix|
+              name = "#{prefix}_#{selector}"
+              name += '?' if prefix.start_with?('has')
+              methods[name.to_sym] = [:selector, kind]
+            end
+          end
+
+          %w[css selector xpath].each do |selector|
+            %W[
+              assert_matches_#{selector} assert_not_matches_#{selector}
+              refute_matches_#{selector} matches_#{selector}?
+              not_matches_#{selector}? match_#{selector} not_match_#{selector}
+              must_match_#{selector} wont_match_#{selector}
+            ].each { |name| methods[name.to_sym] = [:match, selector.to_sym] }
+          end
+
+          %w[text content].each do |kind|
+            %W[
+              assert_#{kind} assert_no_#{kind} refute_#{kind}
+              has_#{kind}? has_no_#{kind}? have_#{kind} have_no_#{kind}
+              must_have_#{kind} wont_have_#{kind}
+            ].each { |name| methods[name.to_sym] = [:text, nil] }
+          end
+
+          %i[
+            attach_file check choose click_button click_link
+            click_link_or_button click_on fill_in select uncheck unselect
+          ].each { |name| methods[name] = [:action, nil] }
+
+          %w[assert have must_have].product(%w[all any none]) do |prefix, count|
+            methods[:"#{prefix}_#{count}_of_selectors"] = %i[grouped selector]
+          end
+
+          methods.transform_values(&:freeze).freeze
+        end
+        private_constant :METHODS, :BUILT_IN_SELECTORS
+
+        module_function
+
+        # @param types [Array<Symbol>]
+        # @return [Array<Symbol>]
+        # @example
+        #   names(:collection) # => [:all, :find_all, :first]
+        def names(*types)
+          METHODS.filter_map { |name, (type, _)| name if types.include?(type) }
+        end
+
+        # @param method_name [Symbol]
+        # @return [Symbol, nil]
+        # @example
+        #   type(:find) # => :finder
+        #   type(:unknown) # => nil
+        def type(method_name)
+          METHODS[method_name]&.first
+        end
+
+        # @param method_name [Symbol]
+        # @return [Symbol, nil]
+        # @example
+        #   selector(:find_button) # => :button
+        #   selector(:find) # => :selector
+        #   selector(:have_text) # => nil
+        def selector(method_name)
+          METHODS[method_name]&.last
+        end
+
+        # @param selector [Symbol]
+        # @return [Boolean]
+        # @example
+        #   built_in_selector?(:css) # => true
+        #   built_in_selector?(:custom) # => false
+        def built_in_selector?(selector)
+          BUILT_IN_SELECTORS.include?(selector)
+        end
+      end
+    end
+  end
+end

--- a/spec/project/lazy_loading_spec.rb
+++ b/spec/project/lazy_loading_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'cop lazy loading' do
       puts "loaded_cop_files=\#{loaded.size}"
     RUBY
 
-    expect(output).to include('registered=15', 'loaded_cop_files=0')
+    expect(output).to include('registered=16', 'loaded_cop_files=0')
   end
 
   it 'does not register a cop twice when its file is required directly' do

--- a/spec/rubocop/cop/capybara/ineffective_query_option_spec.rb
+++ b/spec/rubocop/cop/capybara/ineffective_query_option_spec.rb
@@ -1,0 +1,429 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Capybara::IneffectiveQueryOption, :config do
+  it 'registers offenses for count options passed to singular finders' do
+    expect_offense(<<~RUBY)
+      find('.row', count: 3)
+                   ^^^^^^^^ `count` has no effect when passed to `find`.
+      find_button('Delete', minimum: 2)
+                            ^^^^^^^^^^ `minimum` has no effect when passed to `find_button`.
+      page.find_by_id('row', maximum: 3)
+                             ^^^^^^^^^^ `maximum` has no effect when passed to `find_by_id`.
+      page&.find_field('Name', between: 1..2)
+                               ^^^^^^^^^^^^^ `between` has no effect when passed to `find_field`.
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'registers and corrects `exact` on explicit CSS queries' do
+    expect_offense(<<~RUBY)
+      find(:css, '.item', exact: true)
+                          ^^^^^^^^^^^ `exact` has no effect on CSS queries.
+      page&.find(:css, '.item', exact: false)
+                                ^^^^^^^^^^^^ `exact` has no effect on CSS queries.
+      expect(page).to have_css('.item', exact: true)
+                                        ^^^^^^^^^^^ `exact` has no effect on CSS queries.
+      expect(page).to have_selector(:css, '.item', exact: true)
+                                                   ^^^^^^^^^^^ `exact` has no effect on CSS queries.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find(:css, '.item')
+      page&.find(:css, '.item')
+      expect(page).to have_css('.item')
+      expect(page).to have_selector(:css, '.item')
+    RUBY
+  end
+
+  it 'does not register `exact` when the selector is not explicitly CSS' do
+    expect_no_offenses(<<~RUBY)
+      find('.item', exact: true)
+      find(:xpath, './/item', exact: true)
+      find(:custom, '.item', exact: true)
+      expect(page).to have_xpath('.//item', exact: true)
+      expect(page).to have_selector(selector, '.item', exact: true)
+    RUBY
+  end
+
+  it 'registers and corrects boolean `exact_text` with regexp `text`' do
+    expect_offense(<<~RUBY)
+      find('.item', text: /foo/, exact_text: true)
+                                 ^^^^^^^^^^^^^^^^ `exact_text` has no effect when `text` is a regexp.
+      expect(page).to have_css('.item', exact_text: false, text: %r{foo})
+                                        ^^^^^^^^^^^^^^^^^ `exact_text` has no effect when `text` is a regexp.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find('.item', text: /foo/)
+      expect(page).to have_css('.item', text: %r{foo})
+    RUBY
+  end
+
+  it 'does not register `exact_text` when it can affect the query' do
+    expect_no_offenses(<<~RUBY)
+      find('.item', text: 'foo', exact_text: true)
+      find('.item', text: /foo/, exact_text: 'foo')
+      find('.item', exact_text: /foo/)
+      find('.item', text: pattern, exact_text: true)
+      find(:custom, '.item', text: /foo/, exact_text: true)
+      find(:custom, text: /foo/, exact_text: true)
+      find(selector, '.item', text: /foo/, exact_text: true)
+      expect(page).to have_text('foo', text: /foo/, exact_text: true)
+      find('.item', text: /foo/, exact_text: true, **options)
+      find('.item', text: /foo/, **options, exact_text: true)
+    RUBY
+  end
+
+  it 'ignores keyword splats that could select a custom filter set' do
+    expect_no_offenses(<<~RUBY)
+      find('.item', **options, text: /foo/, exact_text: true)
+    RUBY
+  end
+
+  it 'registers and corrects `match` for collections with built-in selectors' do
+    expect_offense(<<~RUBY)
+      all(:css, '.item', match: :first)
+                         ^^^^^^^^^^^^^ `match` has no effect when passed to `all`.
+      first(:button, 'Delete', match: :one)
+                               ^^^^^^^^^^^ `match` has no effect when passed to `first`.
+      page&.find_all(:xpath, './/item', match: :smart)
+                                        ^^^^^^^^^^^^^ `match` has no effect when passed to `find_all`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      all(:css, '.item')
+      first(:button, 'Delete')
+      page&.find_all(:xpath, './/item')
+    RUBY
+  end
+
+  it 'does not register `match` when the selector may be custom' do
+    expect_no_offenses(<<~RUBY)
+      all('.item', match: :first)
+      all(:custom, '.item', match: :first)
+      first(selector, '.item', match: :one)
+      find(:css, '.item', match: :one)
+      all(:css, '.item', match: strategy)
+      all(:css, '.item', match: :invalid)
+    RUBY
+  end
+
+  it 'ignores match options with unknown keyword splats' do
+    expect_no_offenses(<<~RUBY)
+      all(:css, '.item', match: :first, **options)
+      first(:css, '.item', **options, match: :one)
+    RUBY
+  end
+
+  it 'registers and corrects count options shadowed by `count`' do
+    expect_offense(<<~RUBY)
+      expect(page).to have_css('.item', count: 3, minimum: 1, maximum: 4, between: 2..4)
+                                                  ^^^^^^^^^^ `minimum` has no effect when `count` is specified.
+                                                              ^^^^^^^^^^ `maximum` has no effect when `count` is specified.
+                                                                          ^^^^^^^^^^^^^ `between` has no effect when `count` is specified.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expect(page).to have_css('.item', count: 3)
+    RUBY
+  end
+
+  it 'registers shadowed count options for text queries' do
+    expect_offense(<<~RUBY)
+      expect(page).to have_text('foo', count: 2, minimum: 1)
+                                                 ^^^^^^^^^^ `minimum` has no effect when `count` is specified.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expect(page).to have_text('foo', count: 2)
+    RUBY
+  end
+
+  %w[
+    assert_content assert_no_content refute_text refute_content
+    must_have_text wont_have_text must_have_content wont_have_content
+  ].each do |method|
+    it "registers shadowed count options for `#{method}`" do
+      expect_offense(<<~RUBY, method: method)
+        %{method}('foo', count: 2, minimum: 1)
+        _{method}                  ^^^^^^^^^^ `minimum` has no effect when `count` is specified.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        #{method}('foo', count: 2)
+      RUBY
+    end
+  end
+
+  it 'does not register count options that can affect the query' do
+    expect_no_offenses(<<~RUBY)
+      all('.item', count: 3)
+      all('.item', minimum: 1, maximum: 4, between: 2..4)
+      all('.item', count: nil, minimum: 1)
+      all('.item', count: false, minimum: 1)
+      all('.item', count: expected_count, minimum: 1)
+      all('.item', count: 3, minimum: 1, **options)
+      all('.item', count: 3, **options, minimum: 1)
+      all('.item', count: 3, minimum: 1)
+      all(:custom, '.item', count: 3, minimum: 1)
+      all(selector, '.item', count: 3, minimum: 1)
+    RUBY
+  end
+
+  it 'registers shadowed count options with an explicit built-in selector' do
+    expect_offense(<<~RUBY)
+      all(:css, '.item', count: 3, minimum: 1)
+                                   ^^^^^^^^^^ `minimum` has no effect when `count` is specified.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      all(:css, '.item', count: 3)
+    RUBY
+  end
+
+  it 'ignores count options with unknown keyword splats' do
+    expect_no_offenses(<<~RUBY)
+      all(:css, '.item', **options, count: 3, minimum: 1)
+    RUBY
+  end
+
+  it 'does not register count options rejected by match queries' do
+    expect_no_offenses(<<~RUBY)
+      expect(page).to match_css('.item', count: 3, minimum: 1)
+      page.matches_selector?(:css, '.item', count: 3, minimum: 1)
+    RUBY
+  end
+
+  it 'ignores calls without statically known ineffective options' do
+    expect_no_offenses(<<~RUBY)
+      all
+      all(:css, '.item', option => true)
+      find('.item', exact_text: true)
+    RUBY
+  end
+
+  it 'ignores explicit positional hashes' do
+    expect_no_offenses(<<~RUBY)
+      find('.row', { count: 3 })
+      find(:css, '.item', { exact: true })
+      find('.item', { text: /foo/, exact_text: true })
+      all(:css, '.item', { match: :first })
+      all('.item', { count: 3, minimum: 1 })
+    RUBY
+  end
+
+  it 'does not autocorrect calls containing comments' do
+    expect_offense(<<~RUBY)
+      all(:css, '.item',
+          visible: true, # Keep this comment.
+          match: :first)
+          ^^^^^^^^^^^^^ `match` has no effect when passed to `all`.
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'corrects multiple kinds of ineffective options together' do
+    expect_offense(<<~RUBY)
+      all(:css, '.item', exact: true, text: /foo/, exact_text: true, match: :first, count: 3, minimum: 1)
+                         ^^^^^^^^^^^ `exact` has no effect on CSS queries.
+                                                   ^^^^^^^^^^^^^^^^ `exact_text` has no effect when `text` is a regexp.
+                                                                     ^^^^^^^^^^^^^ `match` has no effect when passed to `all`.
+                                                                                              ^^^^^^^^^^ `minimum` has no effect when `count` is specified.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      all(:css, '.item', text: /foo/, count: 3)
+    RUBY
+  end
+
+  it 'does not treat a symbol locator as a selector type' do
+    expect_no_offenses(<<~RUBY)
+      find_button(:css, exact: true)
+      have_text(:css, exact: true)
+      have_link(:css, exact: true)
+    RUBY
+  end
+
+  it 'preserves side effects in ignored option values' do
+    expect_offense(<<~RUBY)
+      have_css('.item', count: 2, minimum: record_attempt)
+                                  ^^^^^^^^^^^^^^^^^^^^^^^ `minimum` has no effect when `count` is specified.
+      find(:css, '.item', exact: record_attempt)
+                          ^^^^^^^^^^^^^^^^^^^^^ `exact` has no effect on CSS queries.
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'preserves an overriding exact_text option' do
+    expect_offense(<<~RUBY)
+      find('.item', text: /foo/, exact_text: 'bar', exact_text: true)
+                                                    ^^^^^^^^^^^^^^^^ `exact_text` has no effect when `text` is a regexp.
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'does not treat custom filter options as ineffective' do
+    expect_no_offenses(<<~RUBY)
+      have_css('.item', filter_set: :custom, count: 2, minimum: 1)
+      find(:css, '.item', filter_set: :custom, exact: true)
+      all(:css, '.item', filter_set: :custom, match: :first)
+    RUBY
+  end
+
+  it 'handles filter block arguments on assertions' do
+    expect_offense(<<~RUBY)
+      assert_css('.item', exact: true, &filter)
+                          ^^^^^^^^^^^ `exact` has no effect on CSS queries.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      assert_css('.item', &filter)
+    RUBY
+  end
+
+  it 'does not remove the last option leaving an orphaned comma' do
+    expect_offense(<<~RUBY)
+      all(:css, '.item', match: :one,)
+                         ^^^^^^^^^^^ `match` has no effect when passed to `all`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      all(:css, '.item',)
+    RUBY
+  end
+
+  it 'corrects an option-only call and preserves a filter block' do
+    expect_offense(<<~RUBY)
+      have_css(exact: true,)
+               ^^^^^^^^^^^ `exact` has no effect on CSS queries.
+      have_css(exact: true, &filter)
+               ^^^^^^^^^^^ `exact` has no effect on CSS queries.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      have_css()
+      have_css(&filter)
+    RUBY
+  end
+
+  it 'preserves heredocs in ineffective option values' do
+    expect_offense(<<~RUBY)
+      have_css('.item', count: 1, minimum: <<~COUNT)
+                                  ^^^^^^^^^^^^^^^^^ `minimum` has no effect when `count` is specified.
+        1
+      COUNT
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'ignores constants and literal receivers' do
+    expect_no_offenses(<<~RUBY)
+      Model.find(count: 1)
+      [item].find(count: 1)
+    RUBY
+  end
+
+  it 'ignores custom ancestor and sibling selectors' do
+    expect_no_offenses(<<~RUBY)
+      has_ancestor?(:custom, '.item', text: /foo/, exact_text: true)
+      have_sibling(:custom, '.item', count: 2, minimum: 1)
+    RUBY
+  end
+
+  it 'handles count options on specific assertions' do
+    expect_offense(<<~RUBY)
+      assert_link('Home', count: 2, minimum: 1)
+                                    ^^^^^^^^^^ `minimum` has no effect when `count` is specified.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      assert_link('Home', count: 2)
+    RUBY
+  end
+
+  it 'ignores unknown receivers and custom singular selectors' do
+    expect_no_offenses(<<~RUBY)
+      records.find(count: 1)
+      records.first(:css, '.item', match: :first)
+      find(:custom, '.item', count: 1)
+      find(selector, '.item', minimum: 1)
+    RUBY
+  end
+
+  it 'ignores computed option keys that can override known options' do
+    expect_no_offenses(<<~RUBY)
+      have_css('.item', count: 1, minimum: 2, key => nil)
+      find('.item', text: /foo/, exact_text: true, key => 'bar')
+      find(:css, '.item', exact: true, key => :custom)
+    RUBY
+  end
+
+  it 'preserves evaluation of composite literals' do
+    expect_offense(<<~RUBY)
+      have_css('.item', count: 1, minimum: [MissingConstant])
+                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ `minimum` has no effect when `count` is specified.
+      have_css('.item', count: 1, between: 1..'two')
+                                  ^^^^^^^^^^^^^^^^^ `between` has no effect when `count` is specified.
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'recognizes Capybara receivers through finder chains and parentheses' do
+    expect_offense(<<~RUBY)
+      (page).find('.outer') { _1.visible? }.has_css?('.item', exact: true)
+                                                              ^^^^^^^^^^^ `exact` has no effect on CSS queries.
+      ::Capybara.current_session.has_css?('.item', exact: true)
+                                                   ^^^^^^^^^^^ `exact` has no effect on CSS queries.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      (page).find('.outer') { _1.visible? }.has_css?('.item')
+      ::Capybara.current_session.has_css?('.item')
+    RUBY
+  end
+
+  context 'with a custom default selector' do
+    let(:cop_config) { { 'DefaultSelector' => 'custom' } }
+
+    it 'ignores options that can be used by custom filters' do
+      expect_no_offenses(<<~RUBY)
+        find('.item', count: 1)
+        find(count: 1)
+        find('.item', text: /foo/, exact_text: true)
+        have_selector('.item', text: /foo/, exact_text: false)
+        all('.item', match: :first, count: 1, minimum: 2)
+      RUBY
+    end
+
+    it 'still checks explicit built-in and text queries' do
+      expect_offense(<<~RUBY)
+        find(:css, '.item', exact: true)
+                            ^^^^^^^^^^^ `exact` has no effect on CSS queries.
+        have_text('foo', count: 1, minimum: 2)
+                                   ^^^^^^^^^^ `minimum` has no effect when `count` is specified.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        find(:css, '.item')
+        have_text('foo', count: 1)
+      RUBY
+    end
+  end
+
+  context 'with an unknown default selector' do
+    let(:cop_config) { { 'DefaultSelector' => nil } }
+
+    it 'does not infer a selector from the locator' do
+      expect_no_offenses(<<~RUBY)
+        find('.item', count: 1)
+        find('.item', text: /foo/, exact_text: true)
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/capybara/mixin/query_methods_spec.rb
+++ b/spec/rubocop/cop/capybara/mixin/query_methods_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Capybara::QueryMethods do
+  it 'lists singular finders separately from collection finders' do
+    expect(described_class.names(:finder)).to contain_exactly(
+      :find, :ancestor, :sibling, :find_button, :find_by_id,
+      :find_field, :find_link
+    )
+    expect(described_class.names(:collection)).to contain_exactly(
+      :all, :find_all, :first
+    )
+  end
+
+  it 'combines query categories without duplicate methods' do
+    names = described_class.names(:finder, :collection, :finder)
+
+    expect(names.size).to eq(10)
+    expect(names.uniq).to eq(names)
+  end
+
+  it 'classifies each public API family' do
+    expected = {
+      find: :finder, all: :collection, assert_css: :selector,
+      matches_css?: :match, refute_content: :text, click_on: :action,
+      must_have_all_of_selectors: :grouped
+    }
+
+    expected.each do |name, type|
+      expect(described_class.type(name)).to eq(type)
+    end
+  end
+
+  it 'distinguishes selector arguments from fixed selectors' do
+    expected = {
+      find: :selector, have_ancestor: :selector, have_sibling: :selector,
+      have_any_of_selectors: :selector, find_button: :button,
+      has_checked_field?: :field, has_unchecked_field?: :field,
+      assert_css: :css, match_xpath: :xpath, have_text: nil
+    }
+
+    expected.each do |name, selector|
+      expect(described_class.selector(name)).to eq(selector)
+    end
+  end
+
+  it 'recognizes Minitest text aliases but not nonexistent element wrappers' do
+    expect(described_class.names(:text)).to include(
+      :assert_content, :assert_no_content, :refute_text, :refute_content,
+      :must_have_text, :wont_have_text, :must_have_content, :wont_have_content
+    )
+    expect(described_class.names(:selector)).not_to include(
+      :must_have_element, :wont_have_element
+    )
+  end
+
+  it 'does not infer an API category from an unrelated method name' do
+    expect(described_class.type(:have_custom)).to be_nil
+    expect(described_class.selector(:have_custom)).to be_nil
+  end
+
+  it 'returns no methods for an unknown category' do
+    expect(described_class.names(:unknown)).to be_empty
+  end
+
+  it 'distinguishes built-in selectors from custom and unknown selectors' do
+    expect(described_class.built_in_selector?(:css)).to be(true)
+    expect(%i[custom selector].map do |selector|
+      described_class.built_in_selector?(selector)
+    end).to eq([false, false])
+  end
+end


### PR DESCRIPTION
Fixes #211.

Reports query options that Capybara ignores: singular-finder count options, `exact` on explicit CSS queries, boolean `exact_text` with regexp `text`, collection matching strategies, and count limits shadowed by `count`.

Shares public query method classifications with `VisibilityOption` through `QueryMethods`, keeping option-specific rules in each cop.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [x] Added the new cop to `config/default.yml`.
- [x] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [x] The cop documents examples of good and bad code.
- [x] The tests assert both that bad code is reported and that good code is not reported.
- [x] Set `VersionAdded: "<<next>>"` in `config/default.yml`.
