### PR TITLE
Load cops lazily

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,7 @@ Layout/LineLength:
   Max: 80 # default: 120
   AllowedPatterns:
     - '^\s*# .*https?:\/\/.+\[.+\]\.?$' # Allow long asciidoc links
+    - '^\s*register_cop :' # Cop registrations in the department modules
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Edge (Unreleased)
 
+- Speed up loading rubocop-capybara by lazily loading only the cops needed for a run. This requires RuboCop 1.89.0+. ([@koic])
 - Fix an incorrect autocorrect for `Capybara/RedundantWithinFind` when `find_by_id` uses a dynamic id. ([@ydah])
 - Fix a false positive for `Capybara/RSpec/HaveSelector` when `DefaultSelector` is unsupported. ([@ydah])
 - Fix an incorrect autocorrect for `Capybara/SpecificFinders` when a selector class is empty or contains an escaped dot. ([@ydah])

--- a/Rakefile
+++ b/Rakefile
@@ -94,7 +94,7 @@ task :new_cop, [:cop] do |_task, args|
   generator = RuboCop::Capybara::Cop::Generator.new(cop_name)
   generator.write_source
   generator.write_spec
-  generator.inject_require(root_file_path: 'lib/rubocop/cop/capybara_cops.rb')
+  generator.inject_registration
   generator.inject_config
 
   puts generator.todo

--- a/docs/modules/ROOT/pages/development.adoc
+++ b/docs/modules/ROOT/pages/development.adoc
@@ -14,7 +14,7 @@ Use the bundled rake task `new_cop` to generate a cop template:
 $ bundle exec rake 'new_cop[Capybara/CopName]'
 [create] lib/rubocop/cop/capybara/cop_name.rb
 [create] spec/rubocop/cop/capybara/cop_name_spec.rb
-[modify] lib/rubocop/cop/capybara_cops.rb - `require_relative 'capybara/cop_name'` was injected.
+[modify] lib/rubocop/cop/capybara.rb - `register_cop :CopName, "#{__dir__}/capybara/cop_name"` was injected.
 [modify] A configuration for the cop is added into config/default.yml.
 Do 4 steps:
   1. Modify the description of Capybara/CopName in config/default.yml

--- a/lib/rubocop-capybara.rb
+++ b/lib/rubocop-capybara.rb
@@ -9,7 +9,7 @@ require_relative 'rubocop/cop/capybara/mixin/capybara_help'
 require_relative 'rubocop/cop/capybara/mixin/css_attributes_parser'
 require_relative 'rubocop/cop/capybara/mixin/css_selector'
 
-require_relative 'rubocop/cop/capybara_cops'
+require_relative 'rubocop/cop/capybara'
 
 RuboCop::Cop::Style::TrailingCommaInArguments.singleton_class.prepend(
   Module.new do

--- a/lib/rubocop/cop/capybara.rb
+++ b/lib/rubocop/cop/capybara.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative 'capybara/rspec'
+
+module RuboCop
+  module Cop
+    # Cops for the `Capybara` department. The department's cops are
+    # registered for lazy loading and their files are loaded on demand.
+    module Capybara
+      extend LazyLoader
+
+      register_cop :AmbiguousClick, "#{__dir__}/capybara/ambiguous_click"
+      register_cop :AssertStyle, "#{__dir__}/capybara/assert_style"
+      register_cop :FindAllFirst, "#{__dir__}/capybara/find_all_first"
+      register_cop :RedundantWithinFind, "#{__dir__}/capybara/redundant_within_find"
+      register_cop :SpecificActions, "#{__dir__}/capybara/specific_actions"
+      register_cop :SpecificFinders, "#{__dir__}/capybara/specific_finders"
+    end
+  end
+end

--- a/lib/rubocop/cop/capybara/rspec.rb
+++ b/lib/rubocop/cop/capybara/rspec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Capybara
+      # Cops for the `Capybara/RSpec` department. The department's cops are
+      # registered for lazy loading and their files are loaded on demand.
+      module RSpec
+        extend LazyLoader
+
+        register_cop :CurrentPathExpectation, "#{__dir__}/rspec/current_path_expectation"
+        register_cop :HaveContent, "#{__dir__}/rspec/have_content"
+        register_cop :HaveSelector, "#{__dir__}/rspec/have_selector"
+        register_cop :MatchStyle, "#{__dir__}/rspec/match_style"
+        register_cop :NegationMatcher, "#{__dir__}/rspec/negation_matcher"
+        register_cop :NegationMatcherAfterVisit, "#{__dir__}/rspec/negation_matcher_after_visit"
+        register_cop :PredicateMatcher, "#{__dir__}/rspec/predicate_matcher"
+        register_cop :SpecificMatcher, "#{__dir__}/rspec/specific_matcher"
+        register_cop :VisibilityMatcher, "#{__dir__}/rspec/visibility_matcher"
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/capybara_cops.rb
+++ b/lib/rubocop/cop/capybara_cops.rb
@@ -1,18 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'capybara/rspec/current_path_expectation'
-require_relative 'capybara/rspec/have_content'
-require_relative 'capybara/rspec/have_selector'
-require_relative 'capybara/rspec/match_style'
-require_relative 'capybara/rspec/negation_matcher'
-require_relative 'capybara/rspec/negation_matcher_after_visit'
-require_relative 'capybara/rspec/predicate_matcher'
-require_relative 'capybara/rspec/specific_matcher'
-require_relative 'capybara/rspec/visibility_matcher'
-
-require_relative 'capybara/ambiguous_click'
-require_relative 'capybara/assert_style'
-require_relative 'capybara/find_all_first'
-require_relative 'capybara/redundant_within_find'
-require_relative 'capybara/specific_actions'
-require_relative 'capybara/specific_finders'
+# @deprecated This file is deprecated. Cops are registered for lazy loading in
+#   `rubocop/cop/capybara`; this file is kept for compatibility with code that
+#   requires it directly.
+require_relative 'capybara'

--- a/rubocop-capybara.gemspec
+++ b/rubocop-capybara.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_dependency 'lint_roller', '~> 1.1'
-  spec.add_dependency 'rubocop', '~> 1.81'
+  spec.add_dependency 'rubocop', '~> 1.89'
 end

--- a/spec/project/default_config_spec.rb
+++ b/spec/project/default_config_spec.rb
@@ -13,14 +13,7 @@ RSpec.describe 'config/default.yml' do
   end
 
   let(:cop_names) do
-    glob = SpecHelper::ROOT.join('lib', 'rubocop', 'cop', 'capybara',
-                                 '{,rspec}', '*.rb')
-    Pathname.glob(glob).map do |file|
-      file_name = file.basename('.rb').to_s
-      cop_name  = file_name.gsub(/(^|_)(.)/) { Regexp.last_match(2).upcase }
-      namespace = namespaces[file.dirname.basename.to_s]
-      "#{namespace}/#{cop_name}"
-    end
+    RuboCop::Cop::Registry.global.names.grep(%r{\ACapybara/})
   end
 
   let(:config_keys) do

--- a/spec/project/lazy_loading_spec.rb
+++ b/spec/project/lazy_loading_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+RSpec.describe 'cop lazy loading' do
+  def run_script(source)
+    Dir.mktmpdir do |dir|
+      script = File.join(dir, 'script.rb')
+      File.write(script, source)
+      lib = File.expand_path('../../lib', __dir__)
+      output = `#{RbConfig.ruby} -I #{lib} #{script} 2>&1`
+      raise "script failed:\n#{output}" unless $CHILD_STATUS.success?
+
+      output
+    end
+  end
+
+  it 'registers every cop file in both departments exactly once' do
+    cop_root = File.expand_path('../../lib/rubocop/cop', __dir__)
+    files = Dir[File.join(cop_root, 'capybara', '{,rspec/}*.rb')].sort
+    files -= [File.join(cop_root, 'capybara', 'rspec.rb')]
+
+    registered = %w[Capybara Capybara/RSpec].flat_map do |department|
+      cops = RuboCop::Cop::Registry.global.cops_for_department(department.to_sym)
+      cops.map { |cop| Object.const_source_location(cop.name).first }
+    end
+
+    expect(registered.sort).to eq(files)
+  end
+
+  it 'registers all cops without loading their files' do
+    output = run_script(<<~RUBY)
+      require 'rubocop-capybara'
+
+      registry = RuboCop::Cop::Registry.global
+      loaded = $LOADED_FEATURES.grep(%r{/rubocop/cop/capybara/(?!mixin/)(?!rspec\\.rb)})
+
+      puts "registered=\#{registry.names.grep(%r{\\ACapybara/}).size}"
+      puts "loaded_cop_files=\#{loaded.size}"
+    RUBY
+
+    expect(output).to include('registered=15', 'loaded_cop_files=0')
+  end
+
+  it 'does not register a cop twice when its file is required directly' do
+    output = run_script(<<~RUBY)
+      require 'rubocop-capybara'
+
+      before = RuboCop::Cop::Registry.global.length
+      require 'rubocop/cop/capybara/rspec/current_path_expectation'
+      after = RuboCop::Cop::Registry.global.length
+
+      puts "stable=\#{before == after}"
+      puts "class=\#{RuboCop::Cop::Registry.global.find_by_cop_name('Capybara/RSpec/CurrentPathExpectation')}"
+    RUBY
+
+    expect(output).to include('stable=true', 'class=RuboCop::Cop::Capybara::RSpec::CurrentPathExpectation')
+  end
+end


### PR DESCRIPTION
Follow-up to https://github.com/rubocop/rubocop/pull/15436.

Replace the 15 cop requires in `lib/rubocop/cop/capybara_cops.rb` with two department modules that register every cop with the global registry through `RuboCop::Cop::LazyLoader#register_cop` without loading the cop files: `Capybara` in `lib/rubocop/cop/capybara.rb` and the nested `Capybara/RSpec` in `lib/rubocop/cop/capybara/rspec.rb`. A cop's file is loaded only when the cop class is needed, which for an inspection run means only the enabled cops. This follows the same mechanism RuboCop core adopted in rubocop/rubocop#15436 and requires RuboCop 1.89.0+.

The `register_cop` directives keep the former require order (the `Capybara/RSpec` cops before the top-level `Capybara` cops), because the registration order defines the cop execution order. The three mixins stay eagerly required from the gem entry point ahead of the department modules, and the load-time augmentation of `Style/TrailingCommaInArguments` keeps working as is; its reference to `Capybara::RSpec::CurrentPathExpectation` resolves at call time through the autoload.

`lib/rubocop/cop/capybara_cops.rb` is kept as a deprecated compatibility shim for code that requires it directly. The `new_cop` rake task switches from `inject_require` to `inject_registration`, and the development documentation is updated accordingly. The cop name derivation in `spec/project/default_config_spec.rb` switches from file-name camelization to the registry, which knows the registered names without loading the cops and does not mistake the department module file for a cop.

A new `spec/project/lazy_loading_spec.rb` requires every cop file in both department directories to be registered exactly once and asserts the lazy behavior itself in subprocesses: no cop files loaded after `require 'rubocop-capybara'`, and no double registration when a cop file is required directly.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
