### PR TITLE
Add new `Capybara/ModalMethodWithoutBlock` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Edge (Unreleased)
 
+- Add new `Capybara/ModalMethodWithoutBlock` cop. ([@ydah])
 - Speed up loading rubocop-capybara by lazily loading only the cops needed for a run. This requires RuboCop 1.89.0+. ([@koic])
 - Fix an incorrect autocorrect for `Capybara/RedundantWithinFind` when `find_by_id` uses a dynamic id. ([@ydah])
 - Fix a false positive for `Capybara/RSpec/HaveSelector` when `DefaultSelector` is unsupported. ([@ydah])

--- a/config/default.yml
+++ b/config/default.yml
@@ -30,6 +30,12 @@ Capybara/FindAllFirst:
   VersionChanged: '3.0'
   Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/FindAllFirst
 
+Capybara/ModalMethodWithoutBlock:
+  Description: Checks that modal handling methods are called with a block.
+  Enabled: pending
+  VersionAdded: "<<next>>"
+  Reference: https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/ModalMethodWithoutBlock
+
 Capybara/RedundantWithinFind:
   Description: Checks for redundant `within find(...)` calls.
   Enabled: true

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -5,6 +5,7 @@
 * xref:cops_capybara.adoc#capybaraambiguousclick[Capybara/AmbiguousClick]
 * xref:cops_capybara.adoc#capybaraassertstyle[Capybara/AssertStyle]
 * xref:cops_capybara.adoc#capybarafindallfirst[Capybara/FindAllFirst]
+* xref:cops_capybara.adoc#capybaramodalmethodwithoutblock[Capybara/ModalMethodWithoutBlock]
 * xref:cops_capybara.adoc#capybararedundantwithinfind[Capybara/RedundantWithinFind]
 * xref:cops_capybara.adoc#capybaraspecificactions[Capybara/SpecificActions]
 * xref:cops_capybara.adoc#capybaraspecificfinders[Capybara/SpecificFinders]

--- a/docs/modules/ROOT/pages/cops_capybara.adoc
+++ b/docs/modules/ROOT/pages/cops_capybara.adoc
@@ -119,6 +119,40 @@ first('a')
 
 * https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/FindAllFirst
 
+[#capybaramodalmethodwithoutblock]
+== Capybara/ModalMethodWithoutBlock
+
+|===
+| Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
+
+| Pending
+| Yes
+| No
+| <<next>>
+| -
+|===
+
+Checks that modal handling methods are called with a block.
+
+[#examples-capybaramodalmethodwithoutblock]
+=== Examples
+
+[source,ruby]
+----
+# bad
+accept_confirm
+page.accept_prompt(with: 'answer')
+
+# good
+accept_confirm { click_button 'Delete' }
+page.accept_prompt(with: 'answer', &trigger_modal)
+----
+
+[#references-capybaramodalmethodwithoutblock]
+=== References
+
+* https://www.rubydoc.info/gems/rubocop-capybara/RuboCop/Cop/Capybara/ModalMethodWithoutBlock
+
 [#capybararedundantwithinfind]
 == Capybara/RedundantWithinFind
 

--- a/lib/rubocop/cop/capybara.rb
+++ b/lib/rubocop/cop/capybara.rb
@@ -12,6 +12,7 @@ module RuboCop
       register_cop :AmbiguousClick, "#{__dir__}/capybara/ambiguous_click"
       register_cop :AssertStyle, "#{__dir__}/capybara/assert_style"
       register_cop :FindAllFirst, "#{__dir__}/capybara/find_all_first"
+      register_cop :ModalMethodWithoutBlock, "#{__dir__}/capybara/modal_method_without_block"
       register_cop :RedundantWithinFind, "#{__dir__}/capybara/redundant_within_find"
       register_cop :SpecificActions, "#{__dir__}/capybara/specific_actions"
       register_cop :SpecificFinders, "#{__dir__}/capybara/specific_finders"

--- a/lib/rubocop/cop/capybara/modal_method_without_block.rb
+++ b/lib/rubocop/cop/capybara/modal_method_without_block.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Capybara
+      # Checks that modal handling methods are called with a block.
+      #
+      # @example
+      #   # bad
+      #   accept_confirm
+      #   page.accept_prompt(with: 'answer')
+      #
+      #   # good
+      #   accept_confirm { click_button 'Delete' }
+      #   page.accept_prompt(with: 'answer', &trigger_modal)
+      #
+      class ModalMethodWithoutBlock < RuboCop::Cop::Base
+        MSG = 'Call `%<method>s` with a block.'
+        RESTRICT_ON_SEND = %i[
+          accept_alert
+          accept_confirm
+          accept_prompt
+          dismiss_confirm
+          dismiss_prompt
+        ].freeze
+
+        def on_send(node)
+          return if node.block_literal? || node.block_argument?
+          return if node.last_argument&.forwarded_args_type?
+
+          add_offense(node, message: format(MSG, method: node.method_name))
+        end
+        alias on_csend on_send
+      end
+    end
+  end
+end

--- a/spec/project/lazy_loading_spec.rb
+++ b/spec/project/lazy_loading_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'cop lazy loading' do
       puts "loaded_cop_files=\#{loaded.size}"
     RUBY
 
-    expect(output).to include('registered=15', 'loaded_cop_files=0')
+    expect(output).to include('registered=16', 'loaded_cop_files=0')
   end
 
   it 'does not register a cop twice when its file is required directly' do

--- a/spec/rubocop/cop/capybara/modal_method_without_block_spec.rb
+++ b/spec/rubocop/cop/capybara/modal_method_without_block_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Capybara::ModalMethodWithoutBlock do
+  it 'registers offenses for modal methods without a block' do
+    expect_offense(<<~RUBY)
+      accept_alert
+      ^^^^^^^^^^^^ Call `accept_alert` with a block.
+      accept_confirm
+      ^^^^^^^^^^^^^^ Call `accept_confirm` with a block.
+      accept_prompt(with: 'answer')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Call `accept_prompt` with a block.
+      dismiss_confirm
+      ^^^^^^^^^^^^^^^ Call `dismiss_confirm` with a block.
+      dismiss_prompt
+      ^^^^^^^^^^^^^^ Call `dismiss_prompt` with a block.
+    RUBY
+  end
+
+  it 'registers offenses with a receiver or safe navigation' do
+    expect_offense(<<~RUBY)
+      page.accept_confirm
+      ^^^^^^^^^^^^^^^^^^^ Call `accept_confirm` with a block.
+      page&.dismiss_confirm
+      ^^^^^^^^^^^^^^^^^^^^^ Call `dismiss_confirm` with a block.
+    RUBY
+  end
+
+  it 'does not register an offense with a literal block' do
+    expect_no_offenses(<<~RUBY)
+      accept_confirm do
+        click_button 'Delete'
+      end
+      page.dismiss_confirm { click_button 'Cancel' }
+    RUBY
+  end
+
+  it 'does not register an offense with a block-pass argument' do
+    expect_no_offenses(<<~RUBY)
+      accept_prompt(with: 'answer', &trigger_modal)
+    RUBY
+  end
+
+  it 'does not register an offense when forwarding arguments and a block' do
+    expect_no_offenses(<<~RUBY)
+      def trigger(...)
+        page.accept_confirm(...)
+        page&.dismiss_prompt('Answer', ...)
+      end
+    RUBY
+  end
+
+  it 'registers an offense when forwarding arguments without a block' do
+    expect_offense(<<~RUBY)
+      def trigger(*args, **options)
+        accept_confirm(*args, **options)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Call `accept_confirm` with a block.
+      end
+    RUBY
+  end
+
+  it 'does not mistake an enclosing block for a block passed to the modal' do
+    expect_offense(<<~RUBY)
+      tap { accept_confirm }
+            ^^^^^^^^^^^^^^ Call `accept_confirm` with a block.
+    RUBY
+  end
+
+  context 'with anonymous block forwarding' do
+    include_context 'ruby 3.1'
+
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        def trigger(&)
+          accept_confirm(&)
+          page&.dismiss_prompt(with: 'answer', &)
+        end
+      RUBY
+    end
+  end
+
+  it 'recognizes numbered block parameters' do
+    expect_no_offenses(<<~RUBY)
+      page&.accept_prompt { puts _1 }
+    RUBY
+  end
+end


### PR DESCRIPTION
Fixes #229.

Checks calls to Capybara's modal handling methods without a block. Literal blocks (including numbered parameters), explicit or anonymous block arguments, and `...` forwarding are accepted, including calls through safe navigation. No autocorrection is offered because the operation that opens the modal cannot be inferred. 

```ruby
# bad
accept_confirm
page.accept_prompt(with: 'answer')

# good
accept_confirm { click_button 'Delete' }
page.accept_prompt(with: 'answer', &trigger_modal)
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `main` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [x] Added the new cop to `config/default.yml`.
- [x] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [x] The cop documents examples of good and bad code.
- [x] The tests assert both that bad code is reported and that good code is not reported.
- [x] Set `VersionAdded: "<<next>>"` in `config/default.yml`.
